### PR TITLE
PAE-208 remove gov uk secret as its not yet setup for journey tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -127,16 +127,9 @@ services:
      retries: 3
    networks:
      - cdp-tenant
-   secrets:
-     - govuk_notify_api_key
 
 
 networks:
   cdp-tenant:
     driver: bridge
     name: cdp-tenant
-
-secrets:
-  govuk_notify_api_key:
-    environment: "GOVUK_NOTIFY_API_KEY"
-


### PR DESCRIPTION
- removing my last change to fetch govuk_notify_api_key from env variable
- as its not setup in test suite will fail currently. reverting it for now 