### PR TITLE
PAE-256: Add Proxy option in journey tests for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Also provides a data generator facility for local development purposes.
     - [Node.js](#nodejs)
   - [Setup](#setup)
   - [Running local tests](#running-local-tests)
+  - [Running with Proxy](#running-with-proxy)
   - [Running the tests on environments](#running-the-tests-on-environments)
   - [Running the data generator for epr-backend](#running-the-data-generator-for-epr-backend)
 - [What is tested in this test suite](#what-is-tested-in-this-test-suite)
@@ -61,6 +62,32 @@ npm run test:withLogs
 By default, the testing of logs is not enabled (And also not launched during the smoke test in Dev / Test). It is however enabled during PR builds.
 
 The testing of logs and audit logs also assumes that you have run the Docker compose command above as it relies on the Dockerised `epr-backend` service.
+
+### Running with Proxy
+
+By default, Proxy is disabled. To enable it, you first need a Proxy server running. You can use MITM Proxy via this Docker container command:
+
+```
+docker run --rm -it --network host -p 7777:7777 -p 127.0.0.1:8081:8081  mitmproxy/mitmproxy mitmweb --web-host 0.0.0.0 --listen-port 7777
+```
+
+You can now monitor the proxy traffic via http://localhost:8081/ (Use the token on the console output from the Docker command above)
+
+If you wish to use a port number other than 8081 for MITM Proxy (Web), you can pass in the following option at the end of the docker command (e.g. port 8082):
+
+```
+--web-port 8082
+```
+
+Now, you can run the tests with the following command:
+
+```
+WITH_PROXY=true npm run test
+```
+
+Alternatively, you can also use Postman as a Proxy client. For more information, please refer to the [Postman Docs](https://learning.postman.com/docs/sending-requests/capturing-request-data/capture-with-proxy/).
+
+The default Proxy port is 7777. You can change it by modifying the value in `test/config/config.js` under the ProxyAgent configuration.
 
 ### Running the tests on environments
 

--- a/test/apis/base-api.js
+++ b/test/apis/base-api.js
@@ -1,12 +1,11 @@
 import { request } from 'undici'
+import config from '../config/config.js'
 
 let baseUrl
 
 export class BaseAPI {
   constructor() {
-    baseUrl = process.env.ENVIRONMENT
-      ? `https://epr-backend.${process.env.ENVIRONMENT}.cdp-int.defra.cloud`
-      : 'http://localhost:3001'
+    baseUrl = config.api.baseUrl
     this.defaultHeaders = {}
   }
 

--- a/test/config/config.js
+++ b/test/config/config.js
@@ -1,0 +1,31 @@
+import { MongoConnector, StubConnector } from '../support/db.js'
+import { Agent, ProxyAgent } from 'undici'
+
+export default {
+  database: {
+    connector: process.env.ENVIRONMENT
+      ? new StubConnector()
+      : new MongoConnector()
+  },
+  api: {
+    baseUrl: process.env.ENVIRONMENT
+      ? `https://epr-backend.${process.env.ENVIRONMENT}.cdp-int.defra.cloud`
+      : 'http://localhost:3001'
+  },
+  undici: {
+    agent: !process.env.WITH_PROXY
+      ? new Agent({
+          connections: 10,
+          pipelining: 0,
+          headersTimeout: 30000,
+          bodyTimeout: 30000
+        })
+      : new ProxyAgent({
+          uri: 'http://localhost:7777',
+          proxyTunnel: false
+        })
+  },
+  dockerLogParser: {
+    fallbackContainerName: 'epr-backend-epr-backend-1'
+  }
+}

--- a/test/support/docker.log.parser.js
+++ b/test/support/docker.log.parser.js
@@ -1,6 +1,7 @@
 import { exec } from 'child_process'
 import { promisify } from 'util'
 import crypto from 'crypto'
+import config from '../config/config.js'
 
 const execAsync = promisify(exec)
 
@@ -37,7 +38,7 @@ export class DockerLogParser {
       return await this.runDockerCommand(latestTimestamp)
     } catch (error) {
       try {
-        this.containerName = 'epr-backend-epr-backend-1'
+        this.containerName = config.dockerLogParser.fallbackContainerName
         return await this.runDockerCommand(latestTimestamp)
       } catch (error) {
         lastError = error

--- a/test/support/hooks.js
+++ b/test/support/hooks.js
@@ -1,22 +1,25 @@
 import { BeforeAll, AfterAll, After } from '@cucumber/cucumber'
 import fs from 'node:fs'
-import { StubConnector, MongoConnector } from './db.js'
+import config from '../config/config.js'
 
 import { BaseAPI } from '../apis/base-api.js'
+import { setGlobalDispatcher } from 'undici'
 
+let agent
 let dbConnector
 let dbClient
 let baseAPI
 
 BeforeAll(async function () {
-  dbConnector = process.env.ENVIRONMENT
-    ? new StubConnector()
-    : new MongoConnector()
+  dbConnector = config.database.connector
   dbClient = await dbConnector.connect()
   baseAPI = new BaseAPI()
+  agent = config.undici.agent
+  setGlobalDispatcher(agent)
 })
 
 AfterAll(async function () {
+  await agent.close()
   await dbConnector.disconnect()
 })
 


### PR DESCRIPTION
## Description

Add Proxy option in journey test. This allows the Proxy to intercept the requests so that the user who is running the test can have a better understanding on what is being sent in the tests.
