### PR TITLE
PAE-256: Update to proxy configuration to allow usage against environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Also provides a data generator facility for local development purposes.
   - [Running local tests](#running-local-tests)
   - [Running with Proxy](#running-with-proxy)
   - [Running the tests on environments](#running-the-tests-on-environments)
+  - [Running the tests against environments locally](#running-the-tests-against-environments-locally)
   - [Running the data generator for epr-backend](#running-the-data-generator-for-epr-backend)
 - [What is tested in this test suite](#what-is-tested-in-this-test-suite)
 - [Licence](#licence)
@@ -93,6 +94,30 @@ Tests are run from the CDP-Portal under the Test Suites section. Before any chan
 You can check the progress of the build under the actions section of this repository. Builds typically take around 1-2 minutes.
 
 The results of the test run are made available in the portal.
+
+### Running the tests against environments locally
+
+You can also run the tests against environments locally. This can be achieved by supplying the ENVIRONMENT variable.
+
+Ensure ZAP docker container is running and the proxy of your choice is running.
+
+```
+docker compose up -d zap
+```
+
+Then, to run the tests against the `dev` environment:
+
+```
+ENVIRONMENT=dev npm run test
+```
+
+If you want to run the tests with proxy against the `dev` environment, you can do so by supplying the following:
+
+```
+WITH_PROXY=true ENVIRONMENT=dev npm run test
+```
+
+Note that the database checks and logging tests will not run against the `dev` environment as they rely on the local Docker services.
 
 ### Running the data generator for epr-backend
 

--- a/compose.yml
+++ b/compose.yml
@@ -113,9 +113,6 @@ services:
     ports:
       - "8080:8080"
     network_mode: host
-    depends_on:
-      epr-backend:
-        condition: service_healthy
 
 networks:
   cdp-tenant:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1953,6 +1953,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-28.1.0.tgz",
+      "integrity": "sha512-2LzZtOwYKNlCuNf31ajkrekoy2M4z0Z1QGiPH40n4gf5t8VOUFb7m1ojtR4LmGvZxBGvJZP8voOmRqDWzBzYKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "11.1.0"
+      }
+    },
+    "node_modules/@cucumber/gherkin/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@cucumber/html-formatter": {
       "version": "21.14.0",
       "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.14.0.tgz",

--- a/test/support/zap.js
+++ b/test/support/zap.js
@@ -15,7 +15,9 @@ export class ZAPClient {
       url.searchParams.append(key, value)
     })
 
-    const { statusCode, body } = await request(url.toString())
+    const { statusCode, body } = await request(url.toString(), {
+      dispatcher: config.zapAgent
+    })
     if (statusCode !== 200) {
       throw new Error(`ZAP API error: ${statusCode}`)
     }


### PR DESCRIPTION
Ticket: [PAE-256](https://eaflood.atlassian.net/browse/PAE-256)
## Description

- Allow usage of Proxy against lower envs (Dev, Test)
- Safeguard usage of test against Prod environment (Don't allow it)
- Update README

[PAE-256]: https://eaflood.atlassian.net/browse/PAE-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ