### PR TITLE
Pae 274 validate summary logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ WITHOUT_LOGS=true npm run test
 
 The testing of logs and audit logs also assumes that you have run the Docker compose command above as it relies on the Dockerised `epr-backend` service.
 
+### Running tests with tags
+
+For example, if you want to run accreditation tests, you can invoke:
+
+```bash
+npm run test:tagged @accreditation
+```
+
+To run with report, you can invoke:
+
+```bash
+npm run test:tagged @accreditation && npm run report
+```
+
 ### Running with Proxy
 
 By default, Proxy is disabled. To enable it, you first need a Proxy server running. You can use MITM Proxy via this Docker container command:

--- a/compose.yml
+++ b/compose.yml
@@ -90,6 +90,7 @@ services:
      MONGO_URI: mongodb://mongodb:27017/
      GOVUK_NOTIFY_API_KEY: /run/secrets/govuk_notify_api_key
      AUDIT_ENABLED: true
+     FEATURE_FLAG_SUMMARY_LOGS: true
    ports:
      - '3001:3001'
    depends_on:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clean": "rm -rf allure-results && rm -rf allure-report",
     "generatedata": "node ./data/data-generator.js",
     "test": "cucumber-js ; npm run report",
+    "test:tagged": "cucumber-js --tags",
     "format": "prettier --write 'test/**/*.js' '**/*.{js,md,json,config.js}'",
     "format:check": "prettier --check 'test/**/*.js' '**/*.{js,md,json,config.js}'",
     "lint": "eslint .",

--- a/test/features/accreditation.feature
+++ b/test/features/accreditation.feature
@@ -1,3 +1,4 @@
+@accreditation
 Feature: Accreditation endpoint
 
   Scenario: Ensure that accreditation endpoint returns a created response when payload is stored into database

--- a/test/features/healthcheck.feature
+++ b/test/features/healthcheck.feature
@@ -1,6 +1,0 @@
-Feature: Healthcheck endpoint success
-
-  Scenario: Ensure that health endpoint returns success on deployment
-    Given I have access to the EPR backend endpoint
-    When I request the health check
-    Then I should receive the health check response

--- a/test/features/organisation.feature
+++ b/test/features/organisation.feature
@@ -1,3 +1,4 @@
+@organisation
 Feature: Organisation endpoint
 
   Scenario: Ensure that organisation endpoint returns an orgId / reference number and organisation name on response

--- a/test/features/registration.feature
+++ b/test/features/registration.feature
@@ -1,3 +1,4 @@
+@registration
 Feature: Registration endpoint
 
   Scenario: Ensure that registration endpoint returns a response

--- a/test/features/summarylogs.feature
+++ b/test/features/summarylogs.feature
@@ -1,14 +1,23 @@
+@summarylogs
 Feature: Summary Logs validate endpoint
 
   Scenario: Ensure that Summary Logs validate endpoint returns a response
     Given I have entered my summary log validation
     When I submit the summary log validation
     Then I should receive a summary log validating response
+    And the following information appears in the log
+      | Log Level    | INFO                                                                                                           |
+      | Event Action | request_success                                                                                                |
+      | Message      | Initiating file validation for test-bucket/test-key with fileId: test-file-id and filename: test-filename.xlsx |
 
   Scenario: Summary Logs validate endpoint returns an error if s3Key is not present
     Given I have entered my summary log validation without s3Key
     When I submit the summary log validation
     Then I should receive a 422 error response 's3Key is missing in body.data'
+    And the following information appears in the log
+      | Log Level    | WARN                          |
+      | Event Action | response_failure              |
+      | Message      | s3Key is missing in body.data |
 
   Scenario: Summary Logs validate endpoint returns an error if s3Bucket is not present
     Given I have entered my summary log validation without s3Bucket

--- a/test/features/summarylogs.feature
+++ b/test/features/summarylogs.feature
@@ -1,0 +1,40 @@
+Feature: Summary Logs validate endpoint
+
+  Scenario: Ensure that Summary Logs validate endpoint returns a response
+    Given I have entered my summary log validation
+    When I submit the summary log validation
+    Then I should receive a summary log validating response
+
+  Scenario: Summary Logs validate endpoint returns an error if s3Key is not present
+    Given I have entered my summary log validation without s3Key
+    When I submit the summary log validation
+    Then I should receive a 422 error response 's3Key is missing in body.data'
+
+  Scenario: Summary Logs validate endpoint returns an error if s3Bucket is not present
+    Given I have entered my summary log validation without s3Bucket
+    When I submit the summary log validation
+    Then I should receive a 422 error response 's3Bucket is missing in body.data'
+
+  Scenario: Summary Logs validate endpoint returns an error if fileId is not present
+    Given I have entered my summary log validation without fileId
+    When I submit the summary log validation
+    Then I should receive a 422 error response 'fileId is missing in body.data'
+
+  Scenario: Summary Logs validate endpoint returns an error if filename is not present
+    Given I have entered my summary log validation without filename
+    When I submit the summary log validation
+    Then I should receive a 422 error response 'filename is missing in body.data'
+
+  Scenario: Summary Logs validate endpoint returns an error if payload is not present
+    Given I have not entered any details
+    When I submit the summary log validation
+    Then I should receive a 400 error response 'Invalid payload'
+    And the following information appears in the log
+      | Log Level    | WARN             |
+      | Event Action | response_failure |
+      | Message      | Invalid payload  |
+
+  Scenario: Summary Logs validate endpoint returns an error if payload is not a valid object
+    Given I have entered invalid details
+    When I submit the summary log validation
+    Then I should receive a 400 error response 'Invalid payload'

--- a/test/features/zap.feature
+++ b/test/features/zap.feature
@@ -1,3 +1,4 @@
+@zap
 Feature: ZAP scanner tests
 
   Scenario Outline: Ensure that the <EndpointName> endpoint does not return any alerts after ZAP scan
@@ -8,7 +9,8 @@ Feature: ZAP scanner tests
     Then I should receive no alerts from the ZAP report
 
   Examples:
-    | EndpointName  | Url                     | Method |
-    | organisation  | /v1/apply/organisation  | POST   |
-    | accreditation | /v1/apply/accreditation | POST   |
-    | registration  | /v1/apply/registration  | POST   |
+    | EndpointName         | Url                                                              | Method |
+    | organisation         | /v1/apply/organisation                                           | POST   |
+    | accreditation        | /v1/apply/accreditation                                          | POST   |
+    | registration         | /v1/apply/registration                                           | POST   |
+    | summary log validate | /v1/organisation/12345/registration/abcdef/summary-logs/validate | POST   |

--- a/test/step-definitions/summarylogs.steps.js
+++ b/test/step-definitions/summarylogs.steps.js
@@ -1,0 +1,48 @@
+import { Given, Then, When } from '@cucumber/cucumber'
+import { baseAPI } from '../support/hooks.js'
+import { SummaryLog } from '../support/generator.js'
+import { expect } from 'chai'
+
+Given('I have entered my summary log validation', function () {
+  this.summaryLog = new SummaryLog()
+  this.payload = this.summaryLog.toPayload()
+})
+
+Given('I have entered my summary log validation without filename', function () {
+  this.summaryLog = new SummaryLog()
+  this.payload = this.summaryLog.toPayload()
+  delete this.payload.filename
+})
+
+Given('I have entered my summary log validation without fileId', function () {
+  this.summaryLog = new SummaryLog()
+  this.payload = this.summaryLog.toPayload()
+  delete this.payload.fileId
+})
+
+Given('I have entered my summary log validation without s3Bucket', function () {
+  this.summaryLog = new SummaryLog()
+  this.payload = this.summaryLog.toPayload()
+  delete this.payload.s3Bucket
+})
+
+Given('I have entered my summary log validation without s3Key', function () {
+  this.summaryLog = new SummaryLog()
+  this.payload = this.summaryLog.toPayload()
+  delete this.payload.s3Key
+})
+
+When('I submit the summary log validation', async function () {
+  const refNo = '68dc06020897dff9191b1354'
+  const orgId = '500000'
+  this.response = await baseAPI.post(
+    `/v1/organisation/${orgId}/registration/${refNo}/summary-logs/validate`,
+    JSON.stringify(this.payload)
+  )
+})
+
+Then('I should receive a summary log validating response', async function () {
+  expect(this.response.statusCode).to.equal(202)
+  this.responseData = await this.response.body.json()
+  expect(this.responseData.status).to.equal('validating')
+})

--- a/test/support/generator.js
+++ b/test/support/generator.js
@@ -203,3 +203,14 @@ export class Registration {
     return payload
   }
 }
+
+export class SummaryLog {
+  toPayload() {
+    return {
+      s3Bucket: 'test-bucket',
+      s3Key: 'test-key',
+      fileId: 'test-file-id',
+      filename: 'test-filename.xlsx'
+    }
+  }
+}


### PR DESCRIPTION
Ticket: [PAE-274](https://eaflood.atlassian.net/browse/PAE-274)
- Summary logs validate endpoint tests
- Add tagging to cucumber JS tests
- Remove redundant healthcheck test

[PAE-274]: https://eaflood.atlassian.net/browse/PAE-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ