### PR TITLE
PAE-283: Update journey tests for orgId validation

### DIFF
--- a/test/features/accreditation.feature
+++ b/test/features/accreditation.feature
@@ -36,11 +36,11 @@ Feature: Accreditation endpoint
   Scenario: Accreditation endpoint returns a validation error if Organisation ID number does not meet minimum value
     Given I have entered my accreditation details with orgId '5000' and reference number value of 'abcdef123456fedcba654321'
     When I submit the accreditation details
-    Then I should receive a 422 error response 'orgId: 5000, referenceNumber: abcdef123456fedcba654321 - Organisation ID must be at least 500000'
+    Then I should receive a 422 error response 'Organisation ID must be at least 500000'
     And the following information appears in the log
-      | Log Level    | WARN                                                                                                    |
-      | Event Action | response_failure                                                                                        |
-      | Message      | orgId: 5000, referenceNumber: abcdef123456fedcba654321 - Organisation ID must be at least 500000        |
+      | Log Level    | WARN                                                                                             |
+      | Event Action | response_failure                                                                                 |
+      | Message      | orgId: 5000, referenceNumber: abcdef123456fedcba654321 - Organisation ID must be at least 500000 |
 
   Scenario: Accreditation endpoint returns an error if reference number is not present
     Given I have entered my accreditation details without reference number

--- a/test/features/registration.feature
+++ b/test/features/registration.feature
@@ -41,11 +41,11 @@ Feature: Registration endpoint
   Scenario: Registration endpoint returns a validation error if Organisation ID number does not meet minimum value
     Given I have entered my registration details with orgId '5000' and reference number value of 'abcd1234ef567890abcd1234'
     When I submit the registration details
-    Then I should receive a 422 error response 'orgId: 5000, referenceNumber: abcd1234ef567890abcd1234 - Organisation ID must be at least 500000'
+    Then I should receive a 422 error response 'Organisation ID must be at least 500000'
     And the following information appears in the log
-      | Log Level    | WARN                                                                                                   |
-      | Event Action | response_failure                                                                                       |
-      | Message      | orgId: 5000, referenceNumber: abcd1234ef567890abcd1234 - Organisation ID must be at least 500000       |
+      | Log Level    | WARN                                                                                            |
+      | Event Action | response_failure                                                                                |
+      | Message      | orgId: 5000, referenceNumber: abcd1234ef567890abcd1234 - Organisation ID must be at least 500000 |
 
   Scenario: Registration endpoint returns an error if reference number is not present
     Given I have entered my registration details without reference number


### PR DESCRIPTION
Ticket: [PAE-283](https://eaflood.atlassian.net/browse/PAE-283)
## Summary
Update journey tests to match backend changes for orgId validation in PR https://github.com/DEFRA/epr-backend/pull/137

## Changes
- Update expected status code from 500 to 422 for orgId < 500000
- Update expected error message to include orgId and referenceNumber
- Add WARN level log validation for validation failures
- Update scenario descriptions to reflect validation error (not internal server error)

## Dependencies
**Merge order:** This PR must be merged **FIRST**, before https://github.com/DEFRA/epr-backend/pull/137

The journey tests are currently failing against the old backend (returning 500), but will pass once the backend PR is merged and deployed.

## Test plan
Journey tests pass when run against the updated backend with `env WITHOUT_LOGS=true npm run test:tagged @accreditation`

[PAE-283]: https://eaflood.atlassian.net/browse/PAE-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ