### PR TITLE
PAE-310: run zap outside of proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ npm run test:tagged @accreditation && npm run report
 
 By default, Proxy is disabled. To enable it, you first need a Proxy server running. You can use MITM Proxy via this Docker container command:
 
-```
-docker run --rm -it --network host -p 7777:7777 -p 127.0.0.1:8081:8081  mitmproxy/mitmproxy mitmweb --web-host 0.0.0.0 --listen-port 7777
+```sh
+docker run --rm -it --network host -p 7777:7777 -p 127.0.0.1:8081:8081 mitmproxy/mitmproxy mitmweb --web-host 0.0.0.0 --listen-port 7777
+
+# or on macOS
+docker run --rm -it -p 7777:7777 -p 8081:8081 mitmproxy/mitmproxy mitmweb --web-host 0.0.0.0 --listen-port 7777 --set block_global=false
 ```
 
 You can now monitor the proxy traffic via http://localhost:8081/ (Use the token on the console output from the Docker command above)

--- a/test/config/config.js
+++ b/test/config/config.js
@@ -1,5 +1,5 @@
-import { MongoConnector, StubConnector } from '../support/db.js'
 import { Agent, ProxyAgent } from 'undici'
+import { MongoConnector, StubConnector } from '../support/db.js'
 
 const environment = process.env.ENVIRONMENT
 const withProxy = process.env.WITH_PROXY
@@ -29,11 +29,6 @@ const proxy = new ProxyAgent({
   }
 })
 
-const zapProxyAgent = new ProxyAgent({
-  uri: 'http://localhost:7777',
-  proxyTunnel: false
-})
-
 const database = {
   stub: new StubConnector(),
   mongo: new MongoConnector()
@@ -60,7 +55,7 @@ const mongoUri = 'mongodb://localhost:27017/epr-backend'
 
 const testLogs = !withoutLogs && !environment
 const globalUndiciAgent = !withProxy ? agent : proxy
-const zapAgent = !withProxy ? agent : zapProxyAgent
+const zapAgent = agent
 const dbConnector = !environment ? database.mongo : database.stub
 const apiUri = !environment ? api.local : api.env
 const zapTargetApiUri = !environment ? zapTargetApi.local : zapTargetApi.env


### PR DESCRIPTION
Ticket: [PAE-310](https://eaflood.atlassian.net/browse/PAE-310)
## Description

Run ZAP tests outside of proxy (this might be a macOS issue!)

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-310]: https://eaflood.atlassian.net/browse/PAE-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ