### PR TITLE
chore: remove FEATURE_FLAG_OVERSEAS_SITES feature flag

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -173,7 +173,6 @@ services:
       DEFRA_ID_OIDC_WELL_KNOWN_URL: http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/openid-configuration
       ENTRA_OIDC_WELL_KNOWN_CONFIGURATION_URL: http://entra-stub:3010/.well-known/openid-configuration
       FEATURE_FLAG_DEV_ENDPOINTS: true
-      FEATURE_FLAG_OVERSEAS_SITES: true
       FEATURE_FLAG_ORS_WASTE_BALANCE_VALIDATION: true
       FEATURE_FLAG_REPORTS: true
       FEATURE_FLAG_REGISTERED_ONLY: true


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## Summary

- Removed `FEATURE_FLAG_OVERSEAS_SITES: true` environment variable from `compose.yml`
- The overseas sites feature is now permanently enabled; the feature flag is no longer needed

## Changes

| File | Change |
|---|---|
| `compose.yml` | Removed `FEATURE_FLAG_OVERSEAS_SITES: true` env var (line 176) |

## Test plan

- [ ] Journey tests pass without the env var (overseas sites feature is always on now)