### PR TITLE
PAE-1208: Remove FEATURE_FLAG_REGISTERED_ONLY feature flag

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -176,7 +176,6 @@ services:
       FEATURE_FLAG_OVERSEAS_SITES: true
       FEATURE_FLAG_ORS_WASTE_BALANCE_VALIDATION: true
       FEATURE_FLAG_REPORTS: true
-      FEATURE_FLAG_REGISTERED_ONLY: true
       GOVUK_NOTIFY_API_KEY: /run/secrets/govuk_notify_api_key
       LOCALSTACK_ENDPOINT: http://localstack:4566
       LOG_FORMAT: ecs


### PR DESCRIPTION
Ticket: [PAE-1208](https://eaflood.atlassian.net/browse/PAE-1208)
## Summary
Remove `FEATURE_FLAG_REGISTERED_ONLY` from compose.yml.

## Test plan
- [ ] Journey tests still pass

[PAE-1208]: https://eaflood.atlassian.net/browse/PAE-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ