### PR TITLE
PAE-1302: Increase timeout for unbounded smoke tests

### DIFF
--- a/test/step-definitions/organisations.steps.js
+++ b/test/step-definitions/organisations.steps.js
@@ -217,7 +217,7 @@ When(
   }
 )
 
-When('I request the organisations', async function () {
+When('I request the organisations', { timeout: 30000 }, async function () {
   this.response = await eprBackendAPI.get(
     '/v1/organisations',
     authClient.authHeader()

--- a/test/step-definitions/public.register.steps.js
+++ b/test/step-definitions/public.register.steps.js
@@ -6,7 +6,7 @@ import { request } from 'undici'
 import config from '../config/config.js'
 import { parse } from 'csv-parse/sync'
 
-When('I request the public register', async function () {
+When('I request the public register', { timeout: 30000 }, async function () {
   this.response = await eprBackendAPI.post(
     '/v1/public-register/generate',
     '',


### PR DESCRIPTION
Ticket: [PAE-1302](https://eaflood.atlassian.net/browse/PAE-1302)
## Summary

Two smoke tests intermittently time out in deployed environments due to unbounded queries against large datasets:

- **Organisations #1** — `GET /v1/organisations` returns the full organisations list with no pagination
- **Public register #1** — `POST /v1/public-register/generate` internally queries the full organisations table to build the CSV

Response times have been observed up to 17s, well beyond the default 5s Cucumber step timeout.

This adds an explicit 30s timeout to both step definitions as a temporary fix while the root cause (unbounded queries) is addressed.

[PAE-1302]: https://eaflood.atlassian.net/browse/PAE-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ