### PR TITLE
PAE-000: Add reg-only exporter report journey test

### DIFF
--- a/test/features/reports-patch-reprocessor.feature
+++ b/test/features/reports-patch-reprocessor.feature
@@ -31,7 +31,7 @@ Feature: Reports PATCH endpoint for Reprocessor organisations
     When I submit the uploaded summary log
     Then the summary log submission succeeds
 
-    When I create the report for the year 2026 and period 1
+    When I create the 'monthly' report for the year 2026 and period 1
     Then the report is successfully created
 
   Scenario: PATCH with tonnageRecycled succeeds for a reprocessor report

--- a/test/features/reports-patch.feature
+++ b/test/features/reports-patch.feature
@@ -31,7 +31,7 @@ Feature: Reports PATCH endpoint
     When I submit the uploaded summary log
     Then the summary log submission succeeds
 
-    When I create the report for the year 2026 and period 1
+    When I create the 'monthly' report for the year 2026 and period 1
     Then the report is successfully created
 
   Scenario: PATCH with prnRevenue succeeds for an in_progress report

--- a/test/features/reports-registered-only-exporter.feature
+++ b/test/features/reports-registered-only-exporter.feature
@@ -1,0 +1,42 @@
+@reports
+@reports_regonly_exporter
+Feature: Reports for Registered Only Exporter
+
+  Background:
+    Given I create a linked and migrated organisation for the following
+      | wasteProcessingType | withoutAccreditation |
+      | Exporter            | true                 |
+
+    Given I am logged in as a service maintainer
+    When I update the recently migrated organisations data with the following data
+      | regNumber        | status   | validFrom  | withoutAccreditation |
+      | E25SR500030912PA | approved | 2025-02-02 | true                 |
+    Then the organisations data update succeeds
+
+    When I register and authorise a User and link it to the recently migrated organisation
+
+    Given I have the following summary log upload data for summary log upload
+      | s3Bucket            | re-ex-summary-logs                |
+      | s3Key               | exporter-regonly-valid-key         |
+      | fileId              | exporter-regonly-valid-file-id     |
+      | filename            | exporter-regonly-valid.xlsx        |
+      | fileStatus          | complete                           |
+      | registrationNumber  | E25SR500030912PA                   |
+    When I initiate the summary log upload
+    Then the summary log upload initiation succeeds
+    When I submit the summary log upload completed
+    Then I should receive a summary log upload accepted response
+    And the summary log submission status is 'validated'
+    When I submit the uploaded summary log
+    Then the summary log submission succeeds
+    And the summary log submission status is 'submitted'
+
+    When I create the 'quarterly' report for the year 2026 and period 1
+    Then the report is successfully created
+
+  Scenario: Quarterly report contains expected recycling activity
+    When I retrieve the 'quarterly' report for the year 2026 and period 1
+    Then the report is successfully retrieved
+    And the report contains the following information
+      | Key                 | Value    |
+      | wasteProcessingType | exporter |

--- a/test/step-definitions/reporting.steps.js
+++ b/test/step-definitions/reporting.steps.js
@@ -42,10 +42,10 @@ Then(
 )
 
 When(
-  'I create the report for the year {int} and period {int}',
-  async function (year, period) {
+  'I create the {string} report for the year {int} and period {int}',
+  async function (cadence, year, period) {
     this.response = await eprBackendAPI.post(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/monthly/${period}`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}`,
       '',
       defraIdStub.authHeader(this.userId)
     )


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## Summary

Adds an end-to-end journey test for the registered-only exporter reporting flow, covering summary log upload, asynchronous waste record processing, quarterly report creation, and retrieval.

Parameterises the existing `I create the report` Cucumber step to accept a cadence argument so it supports both `monthly` (accredited) and `quarterly` (registered-only) reports. `reports-patch.feature` and `reports-patch-reprocessor.feature` are updated to pass `'monthly'` explicitly — no behaviour change.

## Why

The registered-only exporter reporting path was only exercised by unit tests at the aggregation layer. No journey test covered the full HTTP flow from summary log upload through to quarterly report creation and retrieval. This closes that gap and acts as a regression safety net if any part of the pipeline (xlsx parsing, waste record persistence, async worker, date filtering, aggregation) changes.

The new scenario asserts on `wasteProcessingType` only; it does not verify aggregated tonnage values. Adding tonnage assertions to the reports journey tests (new and existing) is a known gap tracked separately.