### PR TITLE
PAE-1194: Track created orgs and clean up via DELETE endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ coverage
 allure-report/
 allure-results/
 FAILED
+test-artifacts/
 data/*.xlsx

--- a/data/shared-generator-utils.js
+++ b/data/shared-generator-utils.js
@@ -4,6 +4,7 @@ import {
   Organisation,
   Registration
 } from '../test/support/generator.js'
+import { trackCreatedOrgId } from '../test/support/cleanup-tracker.js'
 import logger from '../test/support/logger.js'
 import config from '../test/config/config.js'
 import { FormData, setGlobalDispatcher } from 'undici'
@@ -56,10 +57,12 @@ export async function createOrganisation(context, isNonRegistered) {
   await assertSuccessResponse(orgResponse, '/v1/apply/organisation')
 
   const responseData = await orgResponse.body.json()
+  const orgId = `${responseData.orgId}`
+  trackCreatedOrgId(orgId)
   return {
     organisation,
     referenceNumber: responseData.referenceNumber,
-    orgId: `${responseData.orgId}`
+    orgId
   }
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 # Best-effort cleanup of every orgId the test suite created. Runs regardless
 # of pass/fail — we still want to delete data from failed runs. See PAE-1194.
 cleanup_created_orgs() {
-  id_file="${CLEANUP_ID_FILE:-test-artifacts/created-org-ids.txt}"
+  id_file="test-artifacts/created-org-ids.txt"
   if [ ! -s "$id_file" ]; then
     echo "cleanup: no IDs to clean up"
     return 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,37 @@ if [ "$PROFILE" = "generate" ]; then
     exit 0
 fi
 
+# Best-effort cleanup of every orgId the test suite created. Runs regardless
+# of pass/fail — we still want to delete data from failed runs. See PAE-1194.
+cleanup_created_orgs() {
+  id_file="${CLEANUP_ID_FILE:-test-artifacts/created-org-ids.txt}"
+  if [ ! -s "$id_file" ]; then
+    echo "cleanup: no IDs to clean up"
+    return 0
+  fi
+  if [ -z "$ENVIRONMENT" ]; then
+    echo "cleanup: ENVIRONMENT not set; skipping"
+    return 0
+  fi
+  backend_url="https://epr-backend.${ENVIRONMENT}.cdp-int.defra.cloud"
+  total=$(wc -l < "$id_file" | tr -d ' ')
+  echo "cleanup: deleting $total orgs via $backend_url"
+  fail=0
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    status=$(curl -sS -o /dev/null -w '%{http_code}' \
+      -X DELETE "$backend_url/v1/dev/organisations/$id" || echo "000")
+    echo "  cleanup: $id -> $status"
+    [ "$status" = "200" ] || fail=$((fail + 1))
+  done < "$id_file"
+  echo "cleanup: complete. failures: $fail / $total"
+  return 0
+}
+
 npm run test:tagged @smoketest
+test_exit_code=$?
+
+cleanup_created_orgs
 
 npm run report:publish
 publish_exit_code=$?
@@ -24,6 +54,11 @@ if [ -f FAILED ]; then
   echo "test suite failed"
   cat ./FAILED
   exit 1
+fi
+
+if [ $test_exit_code -ne 0 ]; then
+  echo "test suite exited non-zero"
+  exit $test_exit_code
 fi
 
 echo "test suite passed"

--- a/test/step-definitions/form.submissions.steps.js
+++ b/test/step-definitions/form.submissions.steps.js
@@ -6,6 +6,7 @@ import {
   Organisation,
   Registration
 } from '../support/generator.js'
+import { trackCreatedOrgId } from '../support/cleanup-tracker.js'
 
 Given(
   `I create a linked and migrated organisation for the following`,
@@ -30,6 +31,7 @@ Given(
 
     const orgId = this.orgResponseData?.orgId
     const refNo = this.orgResponseData?.referenceNumber
+    trackCreatedOrgId(orgId)
 
     for (const dataRow of dataRows) {
       this.material = 'Paper or board (R3)'

--- a/test/step-definitions/organisation.steps.js
+++ b/test/step-definitions/organisation.steps.js
@@ -1,6 +1,7 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import { expect } from 'chai'
 import { Organisation } from '../support/generator.js'
+import { trackCreatedOrgId } from '../support/cleanup-tracker.js'
 import { dbClient, eprBackendAPI } from '../support/hooks.js'
 import logger from '../support/logger.js'
 
@@ -65,6 +66,7 @@ Then(
   async function () {
     expect(this.response.statusCode).to.equal(200)
     this.orgResponseData = await this.response.body.json()
+    trackCreatedOrgId(this.orgResponseData?.orgId)
     expect(this.orgResponseData.orgId).to.match(/^\d{6}$/)
     expect(this.orgResponseData.referenceNumber).to.match(/^[0-9a-f]{24}$/i)
     expect(this.orgResponseData.orgName).to.equal(this.organisation.companyName)

--- a/test/support/cleanup-tracker.js
+++ b/test/support/cleanup-tracker.js
@@ -3,8 +3,9 @@ import path from 'node:path'
 import logger from './logger.js'
 
 const cleanupFilePath = path.resolve(
-  process.env.CLEANUP_ID_FILE ??
-    path.join(process.cwd(), 'test-artifacts', 'created-org-ids.txt')
+  process.cwd(),
+  'test-artifacts',
+  'created-org-ids.txt'
 )
 
 function ensureDir() {

--- a/test/support/cleanup-tracker.js
+++ b/test/support/cleanup-tracker.js
@@ -1,0 +1,44 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import logger from './logger.js'
+
+const cleanupFilePath = path.resolve(
+  process.env.CLEANUP_ID_FILE ??
+    path.join(process.cwd(), 'test-artifacts', 'created-org-ids.txt')
+)
+
+function ensureDir() {
+  const dir = path.dirname(cleanupFilePath)
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+}
+
+export function trackCreatedOrgId(orgId) {
+  if (!orgId) {
+    return
+  }
+  try {
+    ensureDir()
+    // Synchronous append so the ID lands on disk before the caller continues —
+    // POSIX guarantees atomic writes under PIPE_BUF (4096 bytes) so concurrent
+    // workers can't interleave partial lines.
+    fs.appendFileSync(cleanupFilePath, `${orgId}\n`)
+  } catch (err) {
+    // Best-effort: never fail a test because the tracker couldn't write.
+    logger.warn(
+      `cleanup-tracker: failed to record orgId ${orgId}: ${err.message}`
+    )
+  }
+}
+
+export function resetTracker() {
+  try {
+    ensureDir()
+    fs.writeFileSync(cleanupFilePath, '')
+  } catch (err) {
+    logger.warn(`cleanup-tracker: failed to reset tracker: ${err.message}`)
+  }
+}
+
+export { cleanupFilePath }

--- a/test/support/hooks.js
+++ b/test/support/hooks.js
@@ -1,9 +1,4 @@
-import {
-  After,
-  AfterAll,
-  BeforeAll,
-  setDefaultTimeout
-} from '@cucumber/cucumber'
+import { After, AfterAll, BeforeAll } from '@cucumber/cucumber'
 import fs from 'node:fs'
 import config from '../config/config.js'
 
@@ -13,6 +8,7 @@ import { AuthClient } from '../support/auth.js'
 import { CDPUploader } from '../support/cdp-uploader.js'
 import { DefraIdStub } from '../support/defra-id-stub.js'
 import Users from '../support/users.js'
+import { resetTracker } from './cleanup-tracker.js'
 import { Interpolator } from './interpolator.js'
 
 let agent
@@ -27,6 +23,7 @@ let cognitoAuth
 let users
 
 BeforeAll({ timeout: 15000 }, async function () {
+  resetTracker()
   dbConnector = config.dbConnector
   dbClient = await dbConnector.connect()
   eprBackendAPI = new EprBackendApi()
@@ -39,10 +36,6 @@ BeforeAll({ timeout: 15000 }, async function () {
   cognitoAuth = config.cognitoAuth
   await cognitoAuth.generateToken()
   setGlobalDispatcher(agent)
-  // Increase timeout to 30s when running Smoke test
-  if (process.env.ENVIRONMENT) {
-    setDefaultTimeout(30000)
-  }
 })
 
 AfterAll(async function () {


### PR DESCRIPTION
Ticket: [PAE-1194](https://eaflood.atlassian.net/browse/PAE-1194)
## Summary

- Record every orgId the suite creates to `test-artifacts/created-org-ids.txt` via a new `trackCreatedOrgId` helper. Three call sites: `createOrganisation` in `shared-generator-utils.js`, the organisation step Then assertion, and the linked+migrated form submission Given.
- After tests finish, `entrypoint.sh` loops the file and calls `DELETE /v1/dev/organisations/{id}` on the environment's backend. Runs regardless of pass/fail; per-ID failures are logged but don't fail the run.
- Revert the temporary `setDefaultTimeout(30000)` workaround from `hooks.js` — shrinking the test/perf env back towards prod-like volumes is the real fix.

Depends on the DELETE endpoint added in DEFRA/epr-backend#1058. Merging this before that endpoint is deployed is harmless: every delete will log a 404 and the suite still passes.

## Why the cleanup lives in `entrypoint.sh`

Journey tests ship as a containerised CDP service — each environment runs a container that executes `entrypoint.sh`. There's no GitHub Actions job to hang a cleanup step off, so cleanup has to happen inside the container. The entrypoint invokes the DELETE endpoint after the cucumber run via plain `curl` (already in the image), using `ENVIRONMENT` to derive the backend URL.

## Test plan

- [ ] CI green on PR (lint, format, docker build)
- [ ] After deploy, watch the first test-env run — check the entrypoint log for `cleanup: deleting N orgs` with non-zero deletes
- [ ] Run the smoke tests twice in a row in test env and confirm `epr-organisations` count stays roughly flat

[PAE-1194]: https://eaflood.atlassian.net/browse/PAE-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ