### PR TITLE
PAE-1330: Remove obsolete feature flags

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -173,10 +173,8 @@ services:
       DEFRA_ID_OIDC_WELL_KNOWN_URL: http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/openid-configuration
       ENTRA_OIDC_WELL_KNOWN_CONFIGURATION_URL: http://entra-stub:3010/.well-known/openid-configuration
       FEATURE_FLAG_DEV_ENDPOINTS: true
-      FEATURE_FLAG_OVERSEAS_SITES: true
       FEATURE_FLAG_ORS_WASTE_BALANCE_VALIDATION: true
       FEATURE_FLAG_REPORTS: true
-      FEATURE_FLAG_REGISTERED_ONLY: true
       GOVUK_NOTIFY_API_KEY: /run/secrets/govuk_notify_api_key
       LOCALSTACK_ENDPOINT: http://localstack:4566
       LOG_FORMAT: ecs


### PR DESCRIPTION
Ticket: [PAE-1330](https://eaflood.atlassian.net/browse/PAE-1330)
## Summary

- Remove `FEATURE_FLAG_OVERSEAS_SITES` and `FEATURE_FLAG_REGISTERED_ONLY` from the backend service environment in `compose.yml`
- These flags are being removed from the service code as part of PAE-1330 and are no longer needed in the journey test configuration

[PAE-1330]: https://eaflood.atlassian.net/browse/PAE-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ