### PR TITLE
PAE-1194: Add EXIT trap to entrypoint.sh so cleanup runs on CDP stop

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,8 @@ cleanup_created_orgs() {
   return 0
 }
 
+trap 'cleanup_created_orgs' EXIT
+
 npm run test:tagged @smoketest
 test_exit_code=$?
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,8 +41,6 @@ trap 'cleanup_created_orgs' EXIT
 npm run test:tagged @smoketest
 test_exit_code=$?
 
-cleanup_created_orgs
-
 npm run report:publish
 publish_exit_code=$?
 


### PR DESCRIPTION
Ticket: [PAE-1194](https://eaflood.atlassian.net/browse/PAE-1194)
## Summary

- Registers `cleanup_created_orgs` via `trap 'cleanup_created_orgs' EXIT` after the function definition, before the test run
- Ensures cleanup fires if CDP kills the container mid-run (SIGTERM), not just on normal exit
- Removes the now-redundant explicit call after the test command

## Test plan

- [ ] Deploy to a test environment and verify cleanup runs on normal test completion
- [ ] Verify cleanup runs when CDP stop is used mid-test (container receives SIGTERM)

[PAE-1194]: https://eaflood.atlassian.net/browse/PAE-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ