### PR TITLE
PAE-1340: Add journey tests for summary log file download logging

### DIFF
--- a/test/features/summarylogs-download.feature
+++ b/test/features/summarylogs-download.feature
@@ -34,4 +34,4 @@ Feature: Summary Logs file download
 
   Scenario: Summary log file download returns 404 for non-existent summary log
     When I download a non-existent summary log file
-    Then I should receive a 404 error response 'Not Found'
+    Then I should receive a 404 error response 'Summary log file not found'

--- a/test/features/summarylogs-download.feature
+++ b/test/features/summarylogs-download.feature
@@ -1,0 +1,37 @@
+@summarylogs
+@summarylogs_download
+Feature: Summary Logs file download
+
+  Background:
+    Given I create a linked and migrated organisation for the following
+      | wasteProcessingType |
+      | Reprocessor         |
+
+    Given I am logged in as a service maintainer
+    When I update the recently migrated organisations data with the following data
+      | reprocessingType | regNumber        | accNumber | status   |
+      | input            | R25SR500030912PA | ACC123456 | approved |
+    Then the organisations data update succeeds
+
+    When I register and authorise a User and link it to the recently migrated organisation
+
+  Scenario: Summary log file download returns redirect and logs structured event
+    Given I have the following summary log upload data for summary log upload
+      | s3Bucket   | re-ex-summary-logs    |
+      | s3Key      | download-test-key     |
+      | fileId     | download-test-file-id |
+      | filename   | download-test.xlsx    |
+      | fileStatus | complete              |
+    When I initiate the summary log upload
+    Then the summary log upload initiation succeeds
+    When I submit the summary log upload completed
+    Then I should receive a summary log upload accepted response
+    When I download the summary log file
+    Then the summary log file download redirects to S3
+    And the following messages appear in the log
+      | Log Level | Event Action    | Message                                                                                                                                  |
+      | info      | request_success | Summary log file downloaded for summaryLogId: {{summaryLogId}}, organisationId: {{summaryLogOrgId}}, registrationId: {{summaryLogRegId}} |
+
+  Scenario: Summary log file download returns 404 for non-existent summary log
+    When I download a non-existent summary log file
+    Then I should receive a 404 error response 'Not Found'

--- a/test/step-definitions/summarylogs.steps.js
+++ b/test/step-definitions/summarylogs.steps.js
@@ -1,6 +1,7 @@
 import { Given, Then, When } from '@cucumber/cucumber'
 import {
   eprBackendAPI,
+  authClient,
   dbClient,
   defraIdStub,
   cdpUploader,
@@ -699,4 +700,27 @@ Then('the submitted summary log should not have an expiry', async function () {
     })
     expect(summaryLog.expiresAt).to.equal(null)
   }
+})
+
+When('I download the summary log file', async function () {
+  const { summaryLogId, orgId, regId } = this.summaryLog
+  this.response = await eprBackendAPI.get(
+    `/v1/organisations/${orgId}/registrations/${regId}/summary-logs/${summaryLogId}/file`,
+    authClient.authHeader()
+  )
+})
+
+Then('the summary log file download redirects to S3', function () {
+  expect(this.response.statusCode).to.equal(302)
+  expect(this.response.responseHeaders.location).to.include(
+    're-ex-summary-logs'
+  )
+})
+
+When('I download a non-existent summary log file', async function () {
+  const nonExistentId = '000000000000000000000000'
+  this.response = await eprBackendAPI.get(
+    `/v1/organisations/${nonExistentId}/registrations/${nonExistentId}/summary-logs/${nonExistentId}/file`,
+    authClient.authHeader()
+  )
 })


### PR DESCRIPTION
Ticket: [PAE-1340](https://eaflood.atlassian.net/browse/PAE-1340)
## What

Adds journey test coverage for the summary log file download endpoint (`GET .../summary-logs/{summaryLogId}/file`), matching the structured logging added in [DEFRA/epr-backend#1069](https://github.com/DEFRA/epr-backend/pull/1069).

## Scenarios

1. **Happy path** — creates an organisation/registration, uploads a summary log, downloads the file, and verifies:
   - 302 redirect to S3
   - Structured `request_success` log message containing summaryLogId, organisationId, and registrationId

2. **404 path** — attempts to download a non-existent summary log file and verifies a 404 error response

## Changes

- New feature file: `test/features/summarylogs-download.feature`
- New step definitions in `test/step-definitions/summarylogs.steps.js`:
  - `I download the summary log file`
  - `the summary log file download redirects to S3`
  - `I download a non-existent summary log file`

[PAE-1340]: https://eaflood.atlassian.net/browse/PAE-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ