### PR TITLE
PAE-1194: Revert smoke test timeout workaround

### DIFF
--- a/test/step-definitions/organisations.steps.js
+++ b/test/step-definitions/organisations.steps.js
@@ -217,7 +217,7 @@ When(
   }
 )
 
-When('I request the organisations', { timeout: 30000 }, async function () {
+When('I request the organisations', async function () {
   this.response = await eprBackendAPI.get(
     '/v1/organisations',
     authClient.authHeader()

--- a/test/step-definitions/public.register.steps.js
+++ b/test/step-definitions/public.register.steps.js
@@ -6,7 +6,7 @@ import { request } from 'undici'
 import config from '../config/config.js'
 import { parse } from 'csv-parse/sync'
 
-When('I request the public register', { timeout: 30000 }, async function () {
+When('I request the public register', async function () {
   this.response = await eprBackendAPI.post(
     '/v1/public-register/generate',
     '',


### PR DESCRIPTION
Ticket: [PAE-1194](https://eaflood.atlassian.net/browse/PAE-1194)

## Summary

- Reverts PR #422 (PAE-1302), which added 30s timeouts to two smoke test steps as a workaround for unbounded queries
- The root cause (unbounded queries on `/v1/organisations` and `/v1/public-register/generate`) has been fixed under PAE-1194, so the timeout workaround is no longer needed

[PAE-1194]: https://eaflood.atlassian.net/browse/PAE-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ