### PR TITLE
PAE-1339: Add advisory type checking to CI

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -40,6 +40,34 @@ jobs:
           npm run format:check
           npm run lint
 
+  type-check:
+    name: Lint Types (advisory)
+    runs-on: ubuntu-latest
+    needs: pr-prep
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Upgrade npm
+        run: npm install -g npm@11.12.1
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Lint types
+        run: |
+          if npm run lint:types; then
+            echo "::notice::Type check passed"
+          else
+            echo "::warning::Type check found errors (advisory — not blocking)"
+          fi
+
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest

--- a/jsconfig.typecheck.json
+++ b/jsconfig.typecheck.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "es2024",
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "noImplicitAny": false,
+    "strictNullChecks": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["test/**/*.js", "data/**/*.js"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "format:check": "prettier --check 'test/**/*.js' '**/*.{js,md,json,config.js}'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:types": "tsc -p jsconfig.typecheck.json",
     "report": "allure generate allure-results --single-file --clean",
     "report:publish": "npm run report; ./bin/publish-tests.sh"
   },


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
## Summary

Introduces `lint:types` as an advisory CI step for this repo, mirroring PAE-1339's rollout in epr-frontend ([#765](https://github.com/DEFRA/epr-frontend/pull/765)).

- `jsconfig.typecheck.json` at repo root covers `test/**/*.js` and `data/**/*.js` with `allowJs` / `checkJs` / `strictNullChecks` on, `noImplicitAny` off — matches the broader rollout's starting posture.
- `lint:types` script added to `package.json` (runs `tsc -p jsconfig.typecheck.json`).
- A new `Lint Types (advisory)` job in the PR workflow runs the script; the step uses an `if` / `else` around `npm run lint:types` so type errors raise a GitHub `::warning::` annotation without failing the job.

Baseline on `main` at introduction: **53** type errors. Fixing them is tracked separately; this PR only wires up the advisory step so the error count is visible on every PR.

The job is deliberately kept minimal (no step-summary report yet) to match PR #765 exactly. Follow-up beads will fix the errors and then flip the step to blocking.

[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ