### PR TITLE
PAE-000: fix all-materials generator for exporter iterations

### DIFF
--- a/data/all-materials-data-generator.js
+++ b/data/all-materials-data-generator.js
@@ -22,7 +22,7 @@ async function generate(options = {}) {
   for (let i = 0; i < 10; i++) {
     let wasteProcessingType = 'exp'
     let isNonRegistered = false
-    let reprocessingType = null
+    let reprocessingType = 'exporter'
 
     if (i % 2 === 0) {
       isNonRegistered = true


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
default `reprocessingType` to `'exporter'` in `data/all-materials-data-generator.js` so the exporter iterations (i=1,5,7) pass a valid value to `generateOrgUpdateData`. previously they left it as `null`, fell through every branch of the helper, returned `undefined`, and broke `updateOrganisationData` on `updateData.status`.

ad-hoc local generator — not used by the test suite or any ci profile (`entrypoint.sh` only wires `allMaterialsMixed` and the default generator). readme documents this script for local dev use.