### PR TITLE
PAE-000: match backend by compose service label in docker log parser

### DIFF
--- a/test/support/docker.log.parser.js
+++ b/test/support/docker.log.parser.js
@@ -41,13 +41,13 @@ export class DockerLogParser {
 
   runDockerCommand = async function (latestTimestamp) {
     const { stdout: psOutput } = await execAsync(
-      `docker ps --filter "name=${this.containerName}" --format "{{.ID}}" | head -1`
+      `docker ps --filter "label=com.docker.compose.service=${this.containerName}" --format "{{.ID}}" | head -1`
     )
     const containerId = psOutput.trim()
 
     if (!containerId) {
       throw new Error(
-        `No running container found with name in: ${this.containerName}`
+        `No running container found for compose service: ${this.containerName}`
       )
     }
 


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## Summary

`DockerLogParser.runDockerCommand` locates the backend container with:

```
docker ps --filter "name=epr-backend" --format "{{.ID}}" | head -1
```

Docker's `name` filter is a substring match. Every container in the compose project shares the `epr-backend-journey-tests-` prefix, so the filter matches them all — the cdp-uploader, defra-id-stub, cognito-stub, mongodb, redis, floci, and entra-stub containers included. `head -1` then picks whichever `docker ps` happens to list first. Most of the time that's the backend; occasionally it's the cdp-uploader.

When the parser ends up reading the uploader's logs, every log-assertion step fails with `TypeError: Cannot read properties of undefined (reading 'log.level')` because `logs[0]` is undefined — the expected messages aren't in the uploader's output.

## Fix

Switch to the compose service label. `com.docker.compose.service=epr-backend` is applied by `docker compose up` to the one service, regardless of project name or container creation ordering. No change to the config: `containerName` is already `'epr-backend'`, which matches the compose service name in `compose.yml`.

## Context

Observed on DEFRA/epr-backend#1104 — 31 scenarios failed identically across two consecutive runs on the rebased branch, while an earlier run on the same branch (and later runs on other branches) passed. The backend emitted every expected log line — the parser just read the wrong container.