### PR TITLE
PAE-250: Fix uuid vulnerability via override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8812,12 +8812,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "pino": "10.3.1",
     "undici": "7.24.5"
   },
+  "overrides": {
+    "uuid": "^14.0.0"
+  },
   "devDependencies": {
     "@babel/core": "7.29.0",
     "@babel/eslint-parser": "7.28.6",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
The `uuid` package below 14.0.0 has a missing buffer bounds check in v3/v5/v6 when `buf` is provided ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq), [SNYK-JS-UUID-16133035](https://security.snyk.io/vuln/SNYK-JS-UUID-16133035)). It reaches this repo transitively via `exceljs`, which is used for generating test spreadsheet data.

`exceljs` still ships an older uuid range, so this pins `uuid` to `^14.0.0` via an `overrides` entry in `package.json` rather than downgrading `exceljs`. `exceljs` only uses `uuid.v4()`, which is unchanged in v14.

After the override, `npm audit` and `snyk test` both report zero vulnerable paths.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ