### PR TITLE
PAE-1396: Add journey test for reconciliation system logs

### DIFF
--- a/test/features/system-logs-reconciliation.feature
+++ b/test/features/system-logs-reconciliation.feature
@@ -1,0 +1,23 @@
+@systemLogsReconciliation
+Feature: System logs - Defra ID reconciliation
+
+  Background:
+    Given I create a linked and migrated organisation for the following
+      | wasteProcessingType |
+      | Reprocessor         |
+
+    Given I am logged in as a service maintainer
+    When I update the recently migrated organisations data with the following data
+      | reprocessingType | regNumber        | accNumber | status   |
+      | input            | R25SR500030912PA | ACC123456 | approved |
+    Then the organisations data update succeeds
+
+    When I register and authorise a User and link it to the recently migrated organisation
+
+  Scenario: Reconciliation system log is created when user discovers organisations
+    When the user discovers their organisations
+    Then the response status code is 200
+    When I search system logs for the user's email with sub-category 'defra-id-reconciliation'
+    Then I receive exactly 1 system log
+    And the system log event action is 'organisations-discovered'
+    And the system log context includes a linked organisation

--- a/test/step-definitions/system-logs-reconciliation.steps.js
+++ b/test/step-definitions/system-logs-reconciliation.steps.js
@@ -1,0 +1,51 @@
+import { Then, When } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { authClient, defraIdStub, eprBackendAPI } from '../support/hooks.js'
+
+When('the user discovers their organisations', async function () {
+  this.response = await eprBackendAPI.get(
+    '/v1/me/organisations',
+    defraIdStub.authHeader(this.userId)
+  )
+})
+
+Then(`the response status code is {int}`, async function (statusCode) {
+  expect(this.response.statusCode).to.equal(statusCode)
+  this.responseData = await this.response.body.json()
+})
+
+When(
+  `I search system logs for the user's email with sub-category {string}`,
+  async function (subCategory) {
+    this.response = await eprBackendAPI.post(
+      '/v1/system-logs/search',
+      JSON.stringify({ email: this.email, subCategory }),
+      authClient.authHeader()
+    )
+    expect(this.response.statusCode).to.equal(200)
+    this.systemLogsResponse = await this.response.body.json()
+  }
+)
+
+Then('I receive exactly {int} system log(s)', function (count) {
+  expect(this.systemLogsResponse.systemLogs).to.have.lengthOf(count)
+})
+
+Then('the system log event action is {string}', function (action) {
+  const [log] = this.systemLogsResponse.systemLogs
+  expect(log.event.action).to.equal(action)
+})
+
+Then('the system log context includes a linked organisation', function () {
+  const [log] = this.systemLogsResponse.systemLogs
+  expect(log.context.linked).to.not.equal(null)
+  expect(log.context.linked).to.have.property('id')
+  expect(log.context.linked).to.have.property('name')
+  expect(log.context.linked).to.have.property('orgId')
+  expect(log.context.linked).to.have.property('status')
+  expect(log.context.linked).to.have.property('linkedBy')
+  expect(log.context.linked).to.have.property('linkedAt')
+  expect(log.context.defraIdOrg).to.have.property('id')
+  expect(log.context.defraIdOrg).to.have.property('name')
+  expect(log.context.defraIdRelationships).to.have.lengthOf.at.least(1)
+})


### PR DESCRIPTION
Ticket: [PAE-1396](https://eaflood.atlassian.net/browse/PAE-1396)

## Summary
- Add journey test verifying the Defra ID reconciliation system log roundtrip
- User discovers organisations (GET /v1/me/organisations), which creates a reconciliation log
- Admin searches for the log (POST /v1/system-logs/search) and asserts the linked organisation context

[PAE-1396]: https://eaflood.atlassian.net/browse/PAE-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ