### PR TITLE
PAE-000: bump base image to node:24.15.0-alpine3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.14.1-alpine3.22
+FROM node:24.15.0-alpine3.22
 
 ENV TZ="Europe/London"
 


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## Summary

- Bump base image from `node:24.14.1-alpine3.22` to `node:24.15.0-alpine3.22`
- Resolves Snyk vulnerabilities reported against the current base image; the new image reports zero
