### PR TITLE
PAE-250: Fix @babel/plugin-transform-modules-systemjs vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -993,9 +993,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "undici": "7.24.5"
   },
   "overrides": {
+    "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## Summary

Pins `@babel/plugin-transform-modules-systemjs` to `7.29.4` via npm `overrides` to remove the high-severity advisory [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) — vulnerable versions in the `7.12.0 – 7.29.0` range generate arbitrary code when compiling malicious input.

The package is pulled in transitively through `@babel/preset-env`; the parent ranges still allow the affected versions, so pinning via `overrides` is the safe semver-compatible fix.

## What changed

- `package.json` — added `@babel/plugin-transform-modules-systemjs: 7.29.4` to `overrides`
- `package-lock.json` — regenerated to apply the override

`npm audit` now reports 0 vulnerabilities.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ