### PR TITLE
PAE-250: Remove stale @babel/plugin-transform-modules-systemjs override

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
The override was originally added to silence a transitive vulnerability. The parent packages have since updated their dependency ranges, so the override no longer changes the resolved tree.

Verified by removing it, re-resolving the lockfile, and confirming both `npm audit` and `snyk test` report no new findings. The remaining `uuid` override and `SNYK-JS-INFLIGHT-6095116` policy ignore were tested the same way and both are still required, so they stay.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ