### PR TITLE
Limit generated spreadsheet ORS ID to 100 only instead of 000 to 999

### DIFF
--- a/data/shared-generator-utils.js
+++ b/data/shared-generator-utils.js
@@ -252,9 +252,8 @@ export async function updateOrganisationData(
     'POST /v1/overseas-sites'
   )
 
-  const overseasSites = {}
-  for (let i = 0; i <= 999; i++) {
-    overseasSites[String(i).padStart(3, '0')] = {
+  const overseasSites = {
+    100: {
       overseasSiteId: site.id
     }
   }

--- a/test/support/spreadsheet/exporter.js
+++ b/test/support/spreadsheet/exporter.js
@@ -58,7 +58,7 @@ export function generateExportedRow(material) {
       faker.string.alpha({ count: 4, casing: 'upper' }) +
       faker.number.int({ min: 1000000, max: 10000000 }), // Container or trailer number / IMO vessel if bulk shipment
     Y: faker.date.recent({ days: 2 }).toLocaleDateString('en-GB'), // Date received by approved overseas reprocessor
-    Z: faker.number.int({ min: 400, max: 700 }), // Approved overseas reprocessor's ID
+    Z: 100, // Approved overseas reprocessor's ID
     AA: interimSite, // Did you export the waste through an interim site? (If yes, provide information for AB and AC)
     AB: interimSiteId, // Interim Site ID (If applicable)
     AC: interimSiteTonnage, // If exported through an interim site, tonnage of UK packaging waste received by overseas reprocessor

--- a/test/support/spreadsheet/exporter.reg.only.js
+++ b/test/support/spreadsheet/exporter.reg.only.js
@@ -43,14 +43,14 @@ export function generateRegOnlyExportedRow() {
       faker.number.float({ min: 1, max: 5, precision: 0.01 }).toFixed(2)
     ), // Tonnage of UK packaging waste exported
     H: date.toLocaleDateString('en-GB'), // Date of export
-    I: faker.number.int({ min: 100, max: 999 }), // Registered overseas reprocessor's ID
+    I: 100, // Registered overseas reprocessor's ID
     J: faker.helpers.arrayElement(BASEL_CODES), // Basel export code
     K: faker.helpers.arrayElement(YES_NO), // Was the waste refused by the recipient destination?
     L: faker.helpers.arrayElement(YES_NO), // Was the waste stopped during the course of export?
     M: repatriatedDate.toLocaleDateString('en-GB'), // Date that the stopped or refused waste was repatriated
 
     // Section 3
-    R: faker.company.name() + ' Limited', // Registered oveseas reprocessor's site name
+    R: faker.company.name() + ' Limited', // Registered overseas reprocessor's site name
     S: reprocessorCountry.name + '-' + reprocessorCountry.code, // Approved overseas reprocessor's country
     T: faker.number.int({ min: 3000000000, max: 4000000000 }), // customs code (HS code)
     U:


### PR DESCRIPTION
Ticket: [PAE-1448](https://eaflood.atlassian.net/browse/PAE-1448)
Limit ORS to 100 for generated organisation to prevent overload in test environment

[PAE-1448]: https://eaflood.atlassian.net/browse/PAE-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ