### PR TITLE
PAE-250: Fix tmp path traversal vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8382,9 +8382,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "undici": "7.24.5"
   },
   "overrides": {
+    "tmp": "0.2.6",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
## What changed

Pins `tmp` to its patched version `0.2.6` via an npm `override`. This fixes a path traversal where an unsanitised prefix/postfix could escape the intended temp directory (high, GHSA-ph9p-34f9-6g65). `tmp` reaches us transitively through `exceljs`, which the data generators use. There are no test or generator code changes.

## Note on `tmp` 0.2.6

This repo's `.npmrc` sets `min-release-age=7`, a quarantine that keeps freshly published packages out of dependency resolution for seven days. `tmp` 0.2.6 is the only release that fixes the path-traversal advisory and it is newer than that window, so it is pinned here as a deliberate exception rather than leaving the high-severity hole open. The published 0.2.5 → 0.2.6 diff was reviewed before adopting it: the only change is the security fix (a new check that rejects `..` in prefix/postfix/template, plus a corrected directory-containment test), it adds no new dependencies and no install scripts, and it comes from the package's long-standing maintainer. `npm ci` installs the lockfile-pinned version irrespective of the age policy, so CI is unaffected.

## Existing policy entries

The existing `uuid` override and the `SNYK-JS-INFLIGHT-6095116` Snyk ignore were both re-checked by removing them and re-testing. Both still suppress live advisories — `exceljs` pulling a vulnerable `uuid`, and `inflight` reached through `exceljs`'s glob chain — so both are retained unchanged.


[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ