### PR TITLE
PAE-1339: Make lint:types a blocking CI check

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -44,17 +44,19 @@ jobs:
     name: Lint Types - Tests
     runs-on: ubuntu-latest
     needs: pr-prep
-    continue-on-error: true
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
-      - uses: DEFRA/epr-re-ex-service/.github/actions/lint-types-tests@main
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          npm-script: lint:types
-          include-globs: |
-            test/**/*.js
-            data/**/*.js
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm install -g npm@11.12.1
+      - run: |
+          npm ci --ignore-scripts
+          npm run lint:types
 
   docker-build:
     name: Docker Build


### PR DESCRIPTION
Ticket: [PAE-1339](https://eaflood.atlassian.net/browse/PAE-1339)
The CI `type-check` job ran the test type check through the shared `lint-types-tests` action, which is advisory by design — it runs `npm run lint:types ... || true`, swallowing the TypeScript exit code and reporting errors only through a sticky PR comment.

The `test/**` and `data/**` sources are now type-clean, so this flips the job to blocking: it checks out the repo, sets up Node from `.nvmrc`, installs dependencies and runs a plain `npm run lint:types`, failing the build on any type error — the same way `lint:types` already blocks in the application repositories. The advisory `continue-on-error` flag, the pull-request comment permissions and the shared action are removed, since a blocking failure is the signal.


[PAE-1339]: https://eaflood.atlassian.net/browse/PAE-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ