### PR TITLE
PAE-1382: Enable waste balance ledger feature flag

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -194,6 +194,7 @@ services:
       FEATURE_FLAG_ORS_WASTE_BALANCE_VALIDATION: true
       FEATURE_FLAG_REPORTS: true
       FEATURE_FLAG_REPORT_UNSUBMIT: true
+      FEATURE_FLAG_WASTE_BALANCE_LEDGER: true
       GOVUK_NOTIFY_API_KEY: /run/secrets/govuk_notify_api_key
       LOG_FORMAT: ecs
       MONGO_URI: mongodb://mongodb:27017/


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

- Enable `FEATURE_FLAG_WASTE_BALANCE_LEDGER` in compose.yml so journey tests run with the ledger path active

Pairs with DEFRA/epr-backend#1215 (stream promotion orchestrator). Branch names match so CI runs journey tests against the backend PR.

## Test plan

- [ ] Journey tests pass with the flag enabled

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ