### PR TITLE
PAE-1540: Update load counts to reflect IGNORED added rows as excluded

### DIFF
--- a/test/features/summarylogs-exporter.feature
+++ b/test/features/summarylogs-exporter.feature
@@ -111,13 +111,13 @@ Feature: Summary Logs - Exporter
       | added.valid    | 3     | 1000,1001,4000 |
       | added.invalid  | 1     | 1003           |
       | added.included | 2     | 1000,1001      |
-      | added.excluded | 1     | 1003           |
+      | added.excluded | 2     | 1002,1003      |
     And the summary log has the following loads for the exported waste record type
       | LoadType       | Count | RowIDs    |
       | added.valid    | 2     | 1000,1001 |
       | added.invalid  | 1     | 1003      |
       | added.included | 2     | 1000,1001 |
-      | added.excluded | 1     | 1003      |
+      | added.excluded | 2     | 1002,1003 |
     And the summary log has the following loads for the sentOn waste record type
       | LoadType       | Count | RowIDs |
       | added.valid    | 1     | 4000   |
@@ -159,34 +159,35 @@ Feature: Summary Logs - Exporter
     And the summary log submission status is 'validated'
 
     # RowId 1000 is adjusted with DATE_RECEIVED_BY_OSR removed, hence should be considered invalid and excluded and not factored in waste balance calculations
+    # RowIds 1002 and 1003 are re-submitted with dates before accreditation validFrom (2025-02-02), so they are IGNORED and show as adjusted.excluded
     And the summary log has the following loads
-      | LoadType           | Count | RowIDs    |
-      | added.valid        | 2     | 1004,4001 |
-      | added.invalid      | 0     |           |
-      | added.included     | 1     | 1004      |
-      | added.excluded     | 0     |           |
-      | unchanged.valid    | 1     | 4000      |
-      | unchanged.invalid  | 0     |           |
-      | unchanged.included | 0     |           |
-      | unchanged.excluded | 0     |           |
-      | adjusted.valid     | 1     | 1001      |
-      | adjusted.invalid   | 1     | 1000      |
-      | adjusted.included  | 1     | 1001      |
-      | adjusted.excluded  | 1     | 1000      |
+      | LoadType           | Count | RowIDs         |
+      | added.valid        | 2     | 1004,4001      |
+      | added.invalid      | 0     |                |
+      | added.included     | 1     | 1004           |
+      | added.excluded     | 0     |                |
+      | unchanged.valid    | 1     | 4000           |
+      | unchanged.invalid  | 0     |                |
+      | unchanged.included | 0     |                |
+      | unchanged.excluded | 0     |                |
+      | adjusted.valid     | 1     | 1001           |
+      | adjusted.invalid   | 1     | 1000           |
+      | adjusted.included  | 1     | 1001           |
+      | adjusted.excluded  | 3     | 1000,1002,1003 |
     And the summary log has the following loads for the exported waste record type
-      | LoadType           | Count | RowIDs |
-      | added.valid        | 1     | 1004   |
-      | added.invalid      | 0     |        |
-      | added.included     | 1     | 1004   |
-      | added.excluded     | 0     |        |
-      | unchanged.valid    | 0     |        |
-      | unchanged.invalid  | 0     |        |
-      | unchanged.included | 0     |        |
-      | unchanged.excluded | 0     |        |
-      | adjusted.valid     | 1     | 1001   |
-      | adjusted.invalid   | 1     | 1000   |
-      | adjusted.included  | 1     | 1001   |
-      | adjusted.excluded  | 1     | 1000   |
+      | LoadType           | Count | RowIDs         |
+      | added.valid        | 1     | 1004           |
+      | added.invalid      | 0     |                |
+      | added.included     | 1     | 1004           |
+      | added.excluded     | 0     |                |
+      | unchanged.valid    | 0     |                |
+      | unchanged.invalid  | 0     |                |
+      | unchanged.included | 0     |                |
+      | unchanged.excluded | 0     |                |
+      | adjusted.valid     | 1     | 1001           |
+      | adjusted.invalid   | 1     | 1000           |
+      | adjusted.included  | 1     | 1001           |
+      | adjusted.excluded  | 3     | 1000,1002,1003 |
     And the summary log has the following loads for the sentOn waste record type
       | LoadType           | Count | RowIDs |
       | added.valid        | 1     | 4001   |
@@ -317,34 +318,35 @@ Feature: Summary Logs - Exporter
 
     # RowId 1000 is adjusted with DATE_RECEIVED_BY_OSR removed, hence should be considered invalid and excluded and not factored in waste balance calculations
     # (Added) Row 1004 no longer picked up as the accreditation is now suspended and the date for Row 1004 is after the suspended date
+    # RowIds 1002 and 1003 are re-submitted with dates before accreditation validFrom (2025-02-02), so they are IGNORED and show as adjusted.excluded
     And the summary log has the following loads
-      | LoadType           | Count | RowIDs |
-      | added.valid        | 1     | 4001   |
-      | added.invalid      | 0     |        |
-      | added.included     | 0     |        |
-      | added.excluded     | 0     |        |
-      | unchanged.valid    | 1     | 4000   |
-      | unchanged.invalid  | 0     |        |
-      | unchanged.included | 0     |        |
-      | unchanged.excluded | 0     |        |
-      | adjusted.valid     | 1     | 1001   |
-      | adjusted.invalid   | 1     | 1000   |
-      | adjusted.included  | 1     | 1001   |
-      | adjusted.excluded  | 1     | 1000   |
+      | LoadType           | Count | RowIDs         |
+      | added.valid        | 1     | 4001           |
+      | added.invalid      | 0     |                |
+      | added.included     | 0     |                |
+      | added.excluded     | 1     | 1004           |
+      | unchanged.valid    | 1     | 4000           |
+      | unchanged.invalid  | 0     |                |
+      | unchanged.included | 0     |                |
+      | unchanged.excluded | 0     |                |
+      | adjusted.valid     | 1     | 1001           |
+      | adjusted.invalid   | 1     | 1000           |
+      | adjusted.included  | 1     | 1001           |
+      | adjusted.excluded  | 3     | 1000,1002,1003 |
     And the summary log has the following loads for the exported waste record type
-      | LoadType           | Count | RowIDs |
-      | added.valid        | 0     |        |
-      | added.invalid      | 0     |        |
-      | added.included     | 0     |        |
-      | added.excluded     | 0     |        |
-      | unchanged.valid    | 0     |        |
-      | unchanged.invalid  | 0     |        |
-      | unchanged.included | 0     |        |
-      | unchanged.excluded | 0     |        |
-      | adjusted.valid     | 1     | 1001   |
-      | adjusted.invalid   | 1     | 1000   |
-      | adjusted.included  | 1     | 1001   |
-      | adjusted.excluded  | 1     | 1000   |
+      | LoadType           | Count | RowIDs         |
+      | added.valid        | 0     |                |
+      | added.invalid      | 0     |                |
+      | added.included     | 0     |                |
+      | added.excluded     | 1     | 1004           |
+      | unchanged.valid    | 0     |                |
+      | unchanged.invalid  | 0     |                |
+      | unchanged.included | 0     |                |
+      | unchanged.excluded | 0     |                |
+      | adjusted.valid     | 1     | 1001           |
+      | adjusted.invalid   | 1     | 1000           |
+      | adjusted.included  | 1     | 1001           |
+      | adjusted.excluded  | 3     | 1000,1002,1003 |
     And the summary log has the following loads for the sentOn waste record type
       | LoadType           | Count | RowIDs |
       | added.valid        | 1     | 4001   |

--- a/test/features/summarylogs-reprocessor-input.feature
+++ b/test/features/summarylogs-reprocessor-input.feature
@@ -116,7 +116,7 @@ Feature: Summary Logs - Reprocessor on Input
       | added.valid        | 4     | 1004,4001,4002,5001 |
       | added.invalid      | 1     | 1005                |
       | added.included     | 2     | 1004,5001           |
-      | added.excluded     | 1     | 1005                |
+      | added.excluded     | 2     | 1003,1005           |
       | unchanged.valid    | 3     | 1000,4000,5000      |
       | unchanged.invalid  | 0     |                      |
       | unchanged.included | 2     | 1000,5000           |
@@ -130,7 +130,7 @@ Feature: Summary Logs - Reprocessor on Input
       | added.valid        | 1     | 1004      |
       | added.invalid      | 1     | 1005      |
       | added.included     | 1     | 1004      |
-      | added.excluded     | 1     | 1005      |
+      | added.excluded     | 2     | 1003,1005 |
       | unchanged.valid    | 1     | 1000      |
       | unchanged.invalid  | 0     |           |
       | unchanged.included | 1     | 1000      |
@@ -268,17 +268,17 @@ Feature: Summary Logs - Reprocessor on Input
     Then the upload to CDP uploader succeeds
     And the summary log submission status is 'validated'
     And the summary log has the following loads
-      | LoadType       | Count | RowIDs |
-      | added.valid    | 1     | 4000   |
-      | added.invalid  | 1     | 1002   |
-      | added.included | 0     |        |
-      | added.excluded | 1     | 1002   |
+      | LoadType       | Count | RowIDs              |
+      | added.valid    | 1     | 4000                |
+      | added.invalid  | 1     | 1002                |
+      | added.included | 0     |                     |
+      | added.excluded | 4     | 1000,1001,1002,5000 |
     And the summary log has the following loads for the received waste record type
-      | LoadType       | Count | RowIDs |
-      | added.valid    | 0     |        |
-      | added.invalid  | 1     | 1002   |
-      | added.included | 0     |        |
-      | added.excluded | 1     | 1002   |
+      | LoadType       | Count | RowIDs         |
+      | added.valid    | 0     |                |
+      | added.invalid  | 1     | 1002           |
+      | added.included | 0     |                |
+      | added.excluded | 3     | 1000,1001,1002 |
     And the summary log has the following loads for the processed waste record type
       | LoadType       | Count | RowIDs |
       | added.valid    | 1     | 4000   |
@@ -290,7 +290,7 @@ Feature: Summary Logs - Reprocessor on Input
       | added.valid    | 0     |        |
       | added.invalid  | 0     |        |
       | added.included | 0     |        |
-      | added.excluded | 0     |        |
+      | added.excluded | 1     | 5000   |
 
     When I submit the uploaded summary log
     Then the summary log submission succeeds

--- a/test/features/summarylogs-reprocessor-output.feature
+++ b/test/features/summarylogs-reprocessor-output.feature
@@ -115,7 +115,7 @@ Feature: Summary Logs - Reprocessor on Output
       | added.valid        | 3     | 1003,3002,5002      |
       | added.invalid      | 2     | 3003,3004           |
       | added.included     | 1     | 3002                |
-      | added.excluded     | 2     | 3003,3004           |
+      | added.excluded     | 3     | 3001,3003,3004      |
       | unchanged.valid    | 5     | 1000,1001,1002,5000,5001 |
       | unchanged.invalid  | 0     |                          |
       | unchanged.included | 0     |                          |
@@ -139,11 +139,11 @@ Feature: Summary Logs - Reprocessor on Output
       | adjusted.included  | 0     |                |
       | adjusted.excluded  | 0     |                |
     And the summary log has the following loads for the processed waste record type
-      | LoadType           | Count | RowIDs    |
-      | added.valid        | 1     | 3002      |
-      | added.invalid      | 2     | 3003,3004 |
-      | added.included     | 1     | 3002      |
-      | added.excluded     | 2     | 3003,3004 |
+      | LoadType           | Count | RowIDs         |
+      | added.valid        | 1     | 3002           |
+      | added.invalid      | 2     | 3003,3004      |
+      | added.included     | 1     | 3002           |
+      | added.excluded     | 3     | 3001,3003,3004 |
       | unchanged.valid    | 0     |           |
       | unchanged.invalid  | 0     |           |
       | unchanged.included | 0     |           |


### PR DESCRIPTION
Ticket: [PAE-1540](https://eaflood.atlassian.net/browse/PAE-1540)
## Summary

- IGNORED rows on first upload (dates outside accreditation range) now surface in `added.excluded` so the user can see which loads were not added to the waste balance
- IGNORED unchanged rows (re-uploaded with no data change) remain hidden
- Updates JT assertions for 5 scenarios across exporter, reprocessor-input, and reprocessor-output features to match the new behaviour

## Context

Companion change to epr-backend PAE-1540 which narrows the IGNORED-row filter in `countByWasteBalanceInclusion`: IGNORED+added and IGNORED+adjusted rows are counted as excluded; IGNORED+unchanged are skipped.

[PAE-1540]: https://eaflood.atlassian.net/browse/PAE-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ