### PR TITLE
PAE-1382: Run journey tests both ways for the waste balance ledger cutover

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -194,6 +194,7 @@ services:
       FEATURE_FLAG_ORS_WASTE_BALANCE_VALIDATION: true
       FEATURE_FLAG_REPORTS: true
       FEATURE_FLAG_REPORT_UNSUBMIT: true
+      FEATURE_FLAG_WASTE_BALANCE_LEDGER: ${FEATURE_FLAG_WASTE_BALANCE_LEDGER:-false}
       GOVUK_NOTIFY_API_KEY: /run/secrets/govuk_notify_api_key
       LOG_FORMAT: ecs
       MONGO_URI: mongodb://mongodb:27017/

--- a/run-journey-tests/action.yml
+++ b/run-journey-tests/action.yml
@@ -10,6 +10,12 @@ inputs:
   journey-test-pr:
     description: is this action being called from a pr in this repo?
     default: 'false'
+  waste-balance-ledger:
+    description: value for FEATURE_FLAG_WASTE_BALANCE_LEDGER in the backend under test
+    default: 'false'
+  artifact-suffix:
+    description: suffix appended to uploaded artifact names to keep concurrent runs distinct
+    default: ''
 
 runs:
   using: 'composite'
@@ -79,6 +85,7 @@ runs:
       shell: bash
       run: |
         EPR_BACKEND=${{ steps.docker-branch.outputs.image }} \
+        FEATURE_FLAG_WASTE_BALANCE_LEDGER=${{ inputs.waste-balance-ledger }} \
         docker compose up --wait-timeout 300 -d --quiet-pull
 
     - name: Start docker compose
@@ -86,6 +93,7 @@ runs:
       shell: bash
       run: |
         EPR_BACKEND=${{ inputs.epr-backend }} \
+        FEATURE_FLAG_WASTE_BALANCE_LEDGER=${{ inputs.waste-balance-ledger }} \
         docker compose up --wait-timeout 300 -d --quiet-pull
 
     - name: Wait for services to be ready
@@ -111,14 +119,14 @@ runs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: allure-report
+        name: allure-report${{ inputs.artifact-suffix }}
         path: ./allure-report
 
     - name: Upload docker compose logs
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: docker-compose-logs
+        name: docker-compose-logs${{ inputs.artifact-suffix }}
         path: ./logs.txt
 
     - name: Fail this step if FAILED file exists


### PR DESCRIPTION
## What

Adds the plumbing so epr-backend CI can run the journey suite against both values of `FEATURE_FLAG_WASTE_BALANCE_LEDGER`, letting the ledger cutover (ADR 0031) be validated as behaviour-preserving without editing any feature files or step definitions.

Two new optional inputs on the `run-journey-tests` action:

- `waste-balance-ledger` — sets `FEATURE_FLAG_WASTE_BALANCE_LEDGER` on the backend under test (default `false`, matching the backend config default), wired through `compose.yml`.
- `artifact-suffix` — appended to the `allure-report` and `docker-compose-logs` artifact names so concurrent runs of the suite don't collide (`upload-artifact@v4` artifact names are immutable per run).

Both defaults are no-ops, so existing single-run callers — including this repo's own PR check — are unchanged.

## Why

[PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382) moves PRN status and waste balances onto an event-sourced ledger as the canonical source. The journey suite is the externally-observable behavioural contract; running it unchanged against both the legacy and ledger paths and getting identical results is the evidence that the migration preserves behaviour.

## Sequencing

The matrix that consumes these inputs lives in the sister PR [DEFRA/epr-backend#1224](https://github.com/DEFRA/epr-backend/pull/1224), which pins this action at `@main`. **This PR must merge to `main` first** — until it does, the new inputs don't exist on `@main`, so the epr-backend matrix would run the legacy path on both legs rather than exercising the ledger.

## Note

This is migration scaffolding. The `false` leg becomes redundant once the ledger is the canonical source and the legacy path is removed, at which point the matrix and these inputs can come back out.


[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ