### PR TITLE
PAE-1382: Verify waste balances via API, not direct MongoDB

### DIFF
--- a/test/features/summarylogs-exporter.feature
+++ b/test/features/summarylogs-exporter.feature
@@ -136,9 +136,6 @@ Feature: Summary Logs - Exporter
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 4000  | sentOn    |
     ## RowId 1000 = 10, RowId 1001 = 20, hence WB = 30. 1001 and 1002 are valid rows
     # RowId 1003 is invalid as it does not have all mandatory fields completed
-    And I should see that waste balances are created in the database with the following values
-      | OrganisationId      | AccreditationId     | Amount | AvailableAmount |
-      | {{summaryLogOrgId}} | {{summaryLogAccId}} | 30     | 30              |
     When I retrieve the waste balance for the organisation
     Then I should see the following waste balance
       | AccreditationId     | Amount | AvailableAmount |
@@ -213,9 +210,6 @@ Feature: Summary Logs - Exporter
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 1004  | exported  |
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 4000  | sentOn    |
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 4001  | sentOn    |
-    And I should see that waste balances are created in the database with the following values
-      | OrganisationId      | AccreditationId     | Amount | AvailableAmount |
-      | {{summaryLogOrgId}} | {{summaryLogAccId}} | 79     | 79              |
     When I retrieve the waste balance for the organisation
     Then I should see the following waste balance
       | AccreditationId     | Amount | AvailableAmount |

--- a/test/features/summarylogs-reprocessor-input.feature
+++ b/test/features/summarylogs-reprocessor-input.feature
@@ -69,9 +69,10 @@ Feature: Summary Logs - Reprocessor on Input
       | {{summaryLogOrgId}} | {{summaryLogRegId}} | 4000  | processed |
       | {{summaryLogOrgId}} | {{summaryLogRegId}} | 5000  | sentOn    |
     And the submitted summary log should not have an expiry
-    And I should see that waste balances are created in the database with the following values
-      | OrganisationId      | AccreditationId     | Amount | AvailableAmount |
-      | {{summaryLogOrgId}} | {{summaryLogAccId}} | 361.62 | 361.62          |
+    When I retrieve the waste balance for the organisation
+    Then I should see the following waste balance
+      | AccreditationId     | Amount | AvailableAmount |
+      | {{summaryLogAccId}} | 361.62 | 361.62          |
 
     # Summary Logs uploads and fails validation for removed row on second upload. This depends on the previous steps being executed
     Given I have the following summary log upload data for summary log upload
@@ -183,10 +184,6 @@ Feature: Summary Logs - Reprocessor on Input
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 4002  | processed |
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 5000  | sentOn    |
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 5001  | sentOn    |
-    And I should see that waste balances are created in the database with the following values
-      | OrganisationId      | AccreditationId     | Amount | AvailableAmount |
-      | {{summaryLogOrgId}} | {{summaryLogAccId}} | 386.51 | 386.51          |
-
     When I retrieve the waste balance for the organisation
     Then I should see the following waste balance
       | AccreditationId     | Amount | AvailableAmount |

--- a/test/features/summarylogs-reprocessor-output.feature
+++ b/test/features/summarylogs-reprocessor-output.feature
@@ -89,9 +89,10 @@ Feature: Summary Logs - Reprocessor on Output
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 3000  | processed |
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 5000  | sentOn    |
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 5001  | sentOn    |
-    And I should see that waste balances are created in the database with the following values
-      | OrganisationId      | AccreditationId     | Amount | AvailableAmount |
-      | {{summaryLogOrgId}} | {{summaryLogAccId}} | 3      | 3               |
+    When I retrieve the waste balance for the organisation
+    Then I should see the following waste balance
+      | AccreditationId     | Amount | AvailableAmount |
+      | {{summaryLogAccId}} | 3      | 3               |
 
     Given I have the following summary log upload data for summary log upload
       | s3Bucket            | re-ex-summary-logs                     |
@@ -183,10 +184,6 @@ Feature: Summary Logs - Reprocessor on Output
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 5000  | sentOn    |
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 5001  | sentOn    |
       | {{summaryLogOrgId}} | {{summaryLogRegId}}  | 5002  | sentOn    |
-    And I should see that waste balances are created in the database with the following values
-      | OrganisationId      | AccreditationId     | Amount | AvailableAmount |
-      | {{summaryLogOrgId}} | {{summaryLogAccId}} | 9.25   | 9.25            |
-
     When I retrieve the waste balance for the organisation
     Then I should see the following waste balance
       | AccreditationId     | Amount | AvailableAmount |

--- a/test/step-definitions/summarylogs.steps.js
+++ b/test/step-definitions/summarylogs.steps.js
@@ -551,57 +551,6 @@ Then(
   }
 )
 
-Then(
-  'I should see that waste balances are created in the database with the following values',
-  async function (dataTable) {
-    if (!process.env.ENVIRONMENT) {
-      const wasteBalancesCollection = dbClient.collection('waste-balances')
-      const expectedWasteBalances = dataTable.hashes()
-      const expectedOrgId = interpolator.interpolate(
-        this,
-        expectedWasteBalances[0].OrganisationId
-      )
-      const expectedAccId = interpolator.interpolate(
-        this,
-        expectedWasteBalances[0].AccreditationId
-      )
-      const wasteBalances = await wasteBalancesCollection
-        .find({
-          organisationId: expectedOrgId,
-          accreditationId: expectedAccId
-        })
-        .toArray()
-      expect(wasteBalances.length).to.equal(expectedWasteBalances.length)
-
-      for (const expectedWasteBalance of expectedWasteBalances) {
-        const matchingRecord = wasteBalances.find(
-          (wasteBalance) =>
-            wasteBalance.organisationId === expectedOrgId &&
-            wasteBalance.accreditationId === expectedAccId &&
-            parseFloat(wasteBalance.amount).toFixed(2) ===
-              parseFloat(expectedWasteBalance.Amount).toFixed(2) &&
-            parseFloat(wasteBalance.availableAmount).toFixed(2) ===
-              parseFloat(expectedWasteBalance.AvailableAmount).toFixed(2)
-        )
-
-        if (!matchingRecord) {
-          expect.fail(
-            `Expected record: ${interpolator.interpolate(this, JSON.stringify(expectedWasteBalance))}, but no waste balances found with those values. Actual waste balances found: ${JSON.stringify(wasteBalances)}`
-          )
-        }
-      }
-    } else {
-      logger.warn(
-        {
-          step_definition:
-            'Then I should see that waste balances are created in the database with the following values'
-        },
-        'Skipping waste balances database checks'
-      )
-    }
-  }
-)
-
 Then('the submitted summary log should not have an expiry', async function () {
   if (!process.env.ENVIRONMENT) {
     const summaryLogsCollection = dbClient.collection('summary-logs')


### PR DESCRIPTION
Ticket: [PAE-1382](https://eaflood.atlassian.net/browse/PAE-1382)
## Summary

Replace direct MongoDB assertions for waste balance amounts with the existing API-based step (`When I retrieve the waste balance` / `Then I should see the following waste balance`).

The direct MongoDB step (`I should see that waste balances are created in the database with the following values`) read `amount` and `availableAmount` from the waste balance document. When `canonicalSource` is `'ledger'`, the document amounts are zero because the event stream is the source of truth. The API endpoint resolves amounts correctly via `resolveBalanceAmounts` regardless of the canonical source.

The dead step definition has been removed from `summarylogs.steps.js`.

Companion to DEFRA/epr-backend#1232.

[PAE-1382]: https://eaflood.atlassian.net/browse/PAE-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ