### PR TITLE
PAE-1544: pin github actions to commit shas

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,6 @@ updates:
     schedule:
       interval: 'cron'
       cronjob: '0 0 * * *'
+
+    cooldown:
+      default-days: 3

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -27,10 +27,10 @@ jobs:
     needs: pr-prep
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Test code and Create Test Coverage Reports
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -46,10 +46,10 @@ jobs:
     needs: pr-prep
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -64,7 +64,7 @@ jobs:
     needs: pr-prep
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build Docker image
         run: docker build .
@@ -75,7 +75,7 @@ jobs:
     needs: pr-prep
     steps:
       - name: Checkout journey-tests repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run journey tests
         uses: ./run-journey-tests

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
     needs: pr-prep
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test code and Create Test Coverage Reports
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -46,7 +46,7 @@ jobs:
     needs: pr-prep
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -64,7 +64,7 @@ jobs:
     needs: pr-prep
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build Docker image
         run: docker build .
@@ -75,7 +75,7 @@ jobs:
     needs: pr-prep
     steps:
       - name: Checkout journey-tests repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run journey tests
         uses: ./run-journey-tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Build the test suite
         uses: DEFRA/cdp-build-action/build-test@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Build the test suite
         uses: DEFRA/cdp-build-action/build-test@main

--- a/run-journey-tests/action.yml
+++ b/run-journey-tests/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Checkout repository if not called by Journey Test PR
       if: inputs.journey-test-pr == 'false'
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         repository: DEFRA/epr-backend-journey-tests
         ref: ${{inputs.branch}}
@@ -43,7 +43,7 @@ runs:
 
     - name: Checkout epr-backend repository if it is Journey Test PR and there is a matching service branch
       if: inputs.journey-test-pr != 'false' && steps.service-branch.outputs.exists == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         repository: DEFRA/epr-backend
         ref: ${{steps.service-branch.outputs.ref}}
@@ -60,7 +60,7 @@ runs:
         docker build -t $IMAGE_TAG .
         echo "image=$EPR_BACKEND_SHA" >> $GITHUB_OUTPUT
 
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: .nvmrc
         cache: npm
@@ -117,14 +117,14 @@ runs:
 
     - name: Upload allure report
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: allure-report${{ inputs.artifact-suffix }}
         path: ./allure-report
 
     - name: Upload docker compose logs
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: docker-compose-logs${{ inputs.artifact-suffix }}
         path: ./logs.txt

--- a/run-journey-tests/action.yml
+++ b/run-journey-tests/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Checkout repository if not called by Journey Test PR
       if: inputs.journey-test-pr == 'false'
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: DEFRA/epr-backend-journey-tests
         ref: ${{inputs.branch}}
@@ -43,7 +43,7 @@ runs:
 
     - name: Checkout epr-backend repository if it is Journey Test PR and there is a matching service branch
       if: inputs.journey-test-pr != 'false' && steps.service-branch.outputs.exists == 'true'
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: DEFRA/epr-backend
         ref: ${{steps.service-branch.outputs.ref}}


### PR DESCRIPTION
[PAE-1544](https://eaflood.atlassian.net/browse/PAE-1544)

pin third-party github actions (with version comments) as per the [defra ci sha-pinning standard](https://defra.github.io/software-development-standards/standards/continuous_integration/#commit-sha-pinning)

[PAE-1544]: https://eaflood.atlassian.net/browse/PAE-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ