### PR TITLE
PAE-1487: Remove obsolete ledger migration journey steps

### DIFF
--- a/test/features/localonly/automated-scaling.feature
+++ b/test/features/localonly/automated-scaling.feature
@@ -25,9 +25,6 @@ Feature: Automated scaling test for Summary Logs Reprocessor on Input
       | maxTotalRows        | 6000             |
       | rowOffset           | 0                |
 
-    When I migrate the Summary Log to ledger
-    Then the Summary Log migration to ledger succeeds
-
     When I generate the Summary Log spreadsheets and upload with the following
       | wasteProcessingType | reprocessorInput |
       | regNumber           | R25SR500030912PA |

--- a/test/features/summarylogs-exporter.feature
+++ b/test/features/summarylogs-exporter.feature
@@ -293,15 +293,6 @@ Feature: Summary Logs - Exporter
       | AccreditationId     | Amount | AvailableAmount |
       | {{summaryLogAccId}} | 30     | 30              |
 
-    # Migrate current Summary Log to ledger, see that the waste balance is not affected before and after adjustment
-    When I migrate the Summary Log to ledger
-    Then the Summary Log migration to ledger succeeds
-
-    When I retrieve the waste balance for the organisation
-    Then I should see the following waste balance
-      | AccreditationId     | Amount | AvailableAmount |
-      | {{summaryLogAccId}} | 30     | 30              |
-
     When I update the accreditation status to 'suspended' at '2026-03-02'
     Then the organisations data update succeeds
 

--- a/test/features/summarylogs-reprocessor-input.feature
+++ b/test/features/summarylogs-reprocessor-input.feature
@@ -74,15 +74,6 @@ Feature: Summary Logs - Reprocessor on Input
       | AccreditationId     | Amount | AvailableAmount |
       | {{summaryLogAccId}} | 361.62 | 361.62          |
 
-    # Migrate current Summary Log to ledger, see that the waste balance is not affected before and after adjustment
-    When I migrate the Summary Log to ledger
-    Then the Summary Log migration to ledger succeeds
-
-    When I retrieve the waste balance for the organisation
-    Then I should see the following waste balance
-      | AccreditationId     | Amount | AvailableAmount |
-      | {{summaryLogAccId}} | 361.62 | 361.62          |
-
     # Summary Logs uploads and fails validation for removed row on second upload. This depends on the previous steps being executed
     Given I have the following summary log upload data for summary log upload
       | s3Bucket   | re-ex-summary-logs                |

--- a/test/features/summarylogs-reprocessor-output.feature
+++ b/test/features/summarylogs-reprocessor-output.feature
@@ -94,15 +94,6 @@ Feature: Summary Logs - Reprocessor on Output
       | AccreditationId     | Amount | AvailableAmount |
       | {{summaryLogAccId}} | 3      | 3               |
 
-    # Migrate current Summary Log to ledger, see that the waste balance is not affected before and after adjustment
-    When I migrate the Summary Log to ledger
-    Then the Summary Log migration to ledger succeeds
-
-    When I retrieve the waste balance for the organisation
-    Then I should see the following waste balance
-      | AccreditationId     | Amount | AvailableAmount |
-      | {{summaryLogAccId}} | 3      | 3               |
-
     Given I have the following summary log upload data for summary log upload
       | s3Bucket            | re-ex-summary-logs                     |
       | s3Key               | reprocessor-output-adjustments-key     |

--- a/test/step-definitions/summarylogs.steps.js
+++ b/test/step-definitions/summarylogs.steps.js
@@ -583,15 +583,3 @@ When('I download a non-existent summary log file', async function () {
     authClient.authHeader()
   )
 })
-
-When('I migrate the Summary Log to ledger', async function () {
-  this.response = await eprBackendAPI.post(
-    `/v1/dev/organisations/${this.summaryLog.orgId}/accreditations/${this.accreditationId}/promote-to-ledger`,
-    '',
-    authClient.authHeader()
-  )
-})
-
-Then('the Summary Log migration to ledger succeeds', async function () {
-  expect(this.response.statusCode).to.equal(200)
-})


### PR DESCRIPTION
Ticket: [PAE-1487](https://eaflood.atlassian.net/browse/PAE-1487)
The event-sourced waste-balance stream is now the sole source of truth in epr-backend, and the transitional `promote-to-ledger` dev endpoint along with the embedded waste-balance path have been removed (DEFRA/epr-backend#1283).

These journey scenarios still drove that removed endpoint via the "I migrate the Summary Log to ledger" step, which now returns a non-200 and fails the suite. The migration step existed only to prove that promoting an embedded balance to the ledger left the balance unchanged; with the ledger as the only path there is nothing to migrate and nothing to assert.

This removes the migration step and its redundant before/after balance re-assertion from the exporter, reprocessor-input and reprocessor-output summary-log features, drops the same step from the local-only automated-scaling feature, and deletes the now-unused step definitions.

[PAE-1487]: https://eaflood.atlassian.net/browse/PAE-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ