### PR TITLE
PAE-1547: add unlink journey tests and fix re-link assertion

### DIFF
--- a/test/apis/epr.backend.api.js
+++ b/test/apis/epr.backend.api.js
@@ -21,6 +21,18 @@ export class EprBackendApi {
     return { statusCode, responseHeaders, body }
   }
 
+  async delete(endpoint, headers = {}) {
+    const {
+      statusCode,
+      headers: responseHeaders,
+      body
+    } = await request(`${eprBackendUrl}${endpoint}`, {
+      method: 'DELETE',
+      headers: { ...this.defaultHeaders, ...headers }
+    })
+    return { statusCode, responseHeaders, body }
+  }
+
   async post(endpoint, data, headers = {}) {
     return await this.#call('POST', endpoint, data, headers)
   }

--- a/test/features/authentication.feature
+++ b/test/features/authentication.feature
@@ -33,7 +33,7 @@ Feature: Authentication tests
 
   Scenario: Should not allow re-linking of linked organisation
     When the User is linked to the recently migrated organisation
-    Then I should receive a 409 error response 'Organisation is not in an approvable state'
+    Then I should receive a 409 error response 'Organisation is already linked'
 
   Scenario: Auth errors are logged when a different user tries to access a recently linked organisation
     When I register and authorise a new User with email 'anothertest123456@testuserz.com'

--- a/test/features/organisation-linking.feature
+++ b/test/features/organisation-linking.feature
@@ -10,8 +10,8 @@ Feature: Linking an organisation to its Defra ID organisation
 
   Scenario: Should not allow linking of an organisation that is not in a linkable state
     When I update the recently migrated organisations data with the following data
-      | reprocessingType | regNumber        | accNumber | status   |
-      | input            | R25SR500030912PA | ACC123456 | rejected |
+      | reprocessingType | regNumber        | accNumber | status  |
+      | input            | R25SR500030912PA | ACC123456 | created |
     Then the organisations data update succeeds
     When I register and authorise a User and link it to the recently migrated organisation
     Then I should receive a 409 error response 'Organisation is not in a linkable state'

--- a/test/features/organisation-linking.feature
+++ b/test/features/organisation-linking.feature
@@ -1,0 +1,17 @@
+@authentication
+Feature: Linking an organisation to its Defra ID organisation
+
+  Background:
+    Given I create a linked and migrated organisation for the following
+      | wasteProcessingType |
+      | Reprocessor         |
+
+    Given I am logged in as a service maintainer
+
+  Scenario: Should not allow linking of an organisation that is not in a linkable state
+    When I update the recently migrated organisations data with the following data
+      | reprocessingType | regNumber        | accNumber | status   |
+      | input            | R25SR500030912PA | ACC123456 | rejected |
+    Then the organisations data update succeeds
+    When I register and authorise a User and link it to the recently migrated organisation
+    Then I should receive a 409 error response 'Organisation is not in a linkable state'

--- a/test/features/organisation-unlinking.feature
+++ b/test/features/organisation-unlinking.feature
@@ -1,0 +1,31 @@
+@authentication
+Feature: Unlinking an organisation from its Defra ID organisation
+
+  Background:
+    Given I create a linked and migrated organisation for the following
+      | wasteProcessingType |
+      | Reprocessor         |
+
+    Given I am logged in as a service maintainer
+    When I update the recently migrated organisations data with the following data
+      | reprocessingType | regNumber        | accNumber | status   |
+      | input            | R25SR500030912PA | ACC123456 | approved |
+    Then the organisations data update succeeds
+
+    When I register and authorise a User and link it to the recently migrated organisation
+
+  Scenario: A service maintainer can unlink a linked organisation
+    When I unlink the recently migrated organisation
+    Then the organisation is unlinked successfully
+
+  Scenario: An unlinked organisation can be re-linked
+    When I unlink the recently migrated organisation
+    Then the organisation is unlinked successfully
+    When the User is linked to the recently migrated organisation
+    Then the organisation link succeeds
+
+  Scenario: Should not allow unlinking an organisation that is not linked
+    When I unlink the recently migrated organisation
+    Then the organisation is unlinked successfully
+    When I unlink the recently migrated organisation
+    Then I should receive a 409 error response 'Organisation is not linked so cannot be unlinked'

--- a/test/step-definitions/unlink.steps.js
+++ b/test/step-definitions/unlink.steps.js
@@ -1,0 +1,20 @@
+import { Then, When } from '@cucumber/cucumber'
+import { expect } from 'chai'
+import { authClient, eprBackendAPI } from '../support/hooks.js'
+
+When('I unlink the recently migrated organisation', async function () {
+  const organisationId = this.orgResponseData?.referenceNumber
+
+  this.response = await eprBackendAPI.delete(
+    `/v1/organisations/${organisationId}/link`,
+    authClient.authHeader()
+  )
+})
+
+Then('the organisation is unlinked successfully', function () {
+  expect(this.response.statusCode).to.equal(204)
+})
+
+Then('the organisation link succeeds', function () {
+  expect(this.response.statusCode).to.equal(200)
+})


### PR DESCRIPTION
Ticket: [PAE-1547](https://eaflood.atlassian.net/browse/PAE-1547)
Add a DELETE helper to the backend API client and cover the new unlink endpoint: unlink a linked org, re-link after unlink, and reject unlinking an unlinked org. Update the re-link-while-linked scenario to expect the new 'Organisation is already linked' 409 message.

## Description

<!-- Describe your changes -->

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1547]: https://eaflood.atlassian.net/browse/PAE-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ