### PR TITLE
PAE-1487: Drop waste-balance-ledger input from run-journey-tests action

### DIFF
--- a/run-journey-tests/action.yml
+++ b/run-journey-tests/action.yml
@@ -10,9 +10,6 @@ inputs:
   journey-test-pr:
     description: is this action being called from a pr in this repo?
     default: 'false'
-  waste-balance-ledger:
-    description: value for FEATURE_FLAG_WASTE_BALANCE_LEDGER in the backend under test
-    default: 'false'
   artifact-suffix:
     description: suffix appended to uploaded artifact names to keep concurrent runs distinct
     default: ''
@@ -85,7 +82,6 @@ runs:
       shell: bash
       run: |
         EPR_BACKEND=${{ steps.docker-branch.outputs.image }} \
-        FEATURE_FLAG_WASTE_BALANCE_LEDGER=${{ inputs.waste-balance-ledger }} \
         docker compose up --wait-timeout 300 -d --quiet-pull
 
     - name: Start docker compose
@@ -93,7 +89,6 @@ runs:
       shell: bash
       run: |
         EPR_BACKEND=${{ inputs.epr-backend }} \
-        FEATURE_FLAG_WASTE_BALANCE_LEDGER=${{ inputs.waste-balance-ledger }} \
         docker compose up --wait-timeout 300 -d --quiet-pull
 
     - name: Wait for services to be ready


### PR DESCRIPTION
## Summary

`FEATURE_FLAG_WASTE_BALANCE_LEDGER` has been removed from epr-backend (PAE-1487), so the `waste-balance-ledger` input on the `run-journey-tests` action — and the two `docker compose` usages that set the now-ignored env var — are dead. This removes them.

The generic, defaulted `artifact-suffix` input is kept.

## Coordination

Pairs with DEFRA/epr-backend#1292, which stops the epr-backend workflow passing this input. The two can merge in either order: the input is optional with a default, and a composite action only warns (never fails) when a caller passes an input it no longer declares.