### PR TITLE
PAE-1559: journey coverage for the accreditation overseas-sites endpoint

### DIFF
--- a/test/features/overseas-sites-accreditation-list.feature
+++ b/test/features/overseas-sites-accreditation-list.feature
@@ -1,0 +1,49 @@
+@overseas_sites
+@overseas_sites_accreditation_list
+Feature: Overseas Sites - Accreditation list
+
+  Scenario: A linked user lists an accreditation's overseas sites with approved and unapproved detail
+    Given I create a linked and migrated organisation for the following
+      | wasteProcessingType | material            |
+      | Exporter            | Paper or board (R3) |
+
+    Given I am logged in as a service maintainer
+    And there are no existing overseas sites
+    When I update the recently migrated organisations data with the following data
+      | regNumber        | accNumber | status   | validFrom  |
+      | R25SR500039901PA | ACC990123 | approved | 2025-02-02 |
+    Then the organisations data update succeeds
+
+    When I register and authorise a User and link it to the recently migrated organisation
+    And I generate the ORS test spreadsheet with the following data
+      | orsId | country | name                 | line1            | line2  | townOrCity | stateOrRegion    | postcode | coordinates     | validFrom  |
+      | 1     | Norway  | Approved Reprocessor | 11 Fjord Lane    | Unit 1 | Oslo       | Oslo             | 0150     | 59.9139,10.7522 | 2025-03-01 |
+      | 2     | Sweden  | Pending Reprocessor  | 22 Harbor Street |        | Stockholm  | Stockholm County | 11122    | 59.3293,18.0686 |            |
+    And I initiate an ORS import
+    Then the ORS import initiation succeeds
+
+    When I upload ORS file 'ors-valid.xlsx' via the CDP uploader
+    Then the upload to CDP uploader succeeds
+
+    When I check the ORS import status
+    Then the ORS import status should be 'completed'
+
+    When I request the overseas sites for the accreditation
+    Then the accreditation overseas sites response should be keyed by ORS id with the following sites
+      | orsId | name                 | country | townOrCity | coordinates     | validFrom                |
+      | 001   | Approved Reprocessor | Norway  | Oslo       | 59.9139,10.7522 | 2025-03-01T00:00:00.000Z |
+      | 002   | Pending Reprocessor  | Sweden  | Stockholm  | 59.3293,18.0686 |                          |
+
+  Scenario: Unauthenticated request for an accreditation's overseas sites is rejected
+    Given I create a linked and migrated organisation for the following
+      | wasteProcessingType | material            |
+      | Exporter            | Paper or board (R3) |
+
+    Given I am logged in as a service maintainer
+    When I update the recently migrated organisations data with the following data
+      | regNumber        | accNumber | status   | validFrom  |
+      | R25SR500039901PA | ACC990123 | approved | 2025-02-02 |
+    Then the organisations data update succeeds
+
+    When I request the overseas sites for the accreditation without authentication
+    Then the accreditation overseas sites status should be 401

--- a/test/step-definitions/overseas-sites.steps.js
+++ b/test/step-definitions/overseas-sites.steps.js
@@ -5,6 +5,7 @@ import {
   basicAuth,
   cdpUploader,
   dbClient,
+  defraIdStub,
   eprBackendAPI,
   interpolator
 } from '../support/hooks.js'
@@ -668,5 +669,63 @@ Then(
       hasNextPage: page < totalPages,
       hasPreviousPage: page > 1
     })
+  }
+)
+
+const accreditationOverseasSitesPath = (world) =>
+  `/v1/organisations/${world.organisationId}/registrations/${world.registrationId}/accreditations/${world.accreditationId}/overseas-sites`
+
+When('I request the overseas sites for the accreditation', async function () {
+  this.response = await eprBackendAPI.get(
+    accreditationOverseasSitesPath(this),
+    defraIdStub.authHeader(this.userId)
+  )
+})
+
+When(
+  'I request the overseas sites for the accreditation without authentication',
+  async function () {
+    this.response = await eprBackendAPI.get(
+      accreditationOverseasSitesPath(this)
+    )
+  }
+)
+
+Then(
+  'the accreditation overseas sites status should be {int}',
+  async function (statusCode) {
+    expect(this.response.statusCode).to.equal(statusCode)
+  }
+)
+
+Then(
+  'the accreditation overseas sites response should be keyed by ORS id with the following sites',
+  async function (dataTable) {
+    expect(this.response.statusCode).to.equal(200)
+    const body = await this.response.body.json()
+
+    const expectedRows = dataTable.hashes()
+    expect(Object.keys(body).sort()).to.deep.equal(
+      expectedRows.map((row) => row.orsId).sort()
+    )
+
+    for (const expected of expectedRows) {
+      const entry = body[expected.orsId]
+      // eslint-disable-next-line no-unused-expressions
+      expect(entry, `Expected an entry keyed by ORS id ${expected.orsId}`).to
+        .not.be.undefined
+      expect(entry.name).to.equal(expected.name)
+      expect(entry.country).to.equal(expected.country)
+      expect(entry.address.townOrCity).to.equal(expected.townOrCity)
+      expect(entry.coordinates).to.equal(expected.coordinates)
+
+      if (expected.validFrom === '') {
+        // eslint-disable-next-line no-unused-expressions
+        expect(entry.validFrom, `ORS ${expected.orsId} is unapproved`).to.be
+          .null
+      } else {
+        expect(entry.validFrom).to.equal(expected.validFrom)
+      }
+    }
   }
 )


### PR DESCRIPTION
Ticket: [PAE-1559](https://eaflood.atlassian.net/browse/PAE-1559)
Adds end-to-end journey coverage for the new additive backend route `GET /v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/overseas-sites`, which returns an accreditation's overseas sites as a map keyed by the three-digit ORS id (each entry carrying name, country, address, coordinates and `validFrom`).

## What this adds

- A new feature, `test/features/overseas-sites-accreditation-list.feature`, with two scenarios. The first has a linked standard user list an accreditation's overseas sites: it seeds a real organisation → registration → accreditation and imports overseas sites through the ORS spreadsheet upload (reusing the admin-list seeding chain), then asserts the response is keyed by the three-digit ORS id and discriminates an approved site (Valid From populated → ISO `validFrom`) from an unapproved one (Valid From blank → `null`), checking name, country, town/city and coordinates. The second asserts an unauthenticated request is rejected with 401.
- Four supporting step definitions in `test/step-definitions/overseas-sites.steps.js`. The authenticated path uses the linked Defra ID standard user, mirroring the sibling PRN steps on the same accreditation path, so it exercises the endpoint's `standardUser`/`organisationRead` scope.

## Sequencing

The endpoint lands in epr-backend [#1302](https://github.com/DEFRA/epr-backend/pull/1302). This branch is named to match the `PAE-1559-accreditation-overseas-sites` branch in epr-backend, so the journey-test CI builds the backend image from that branch and runs the new scenario against it. This PR must not merge ahead of [#1302](https://github.com/DEFRA/epr-backend/pull/1302), and is kept as a draft until that backend change merges.


[PAE-1559]: https://eaflood.atlassian.net/browse/PAE-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ