### PR TITLE
PAE-1541: Assert loadsByReportingPeriod in journey tests

### DIFF
--- a/test/features/summarylogs-exporter-registered-only.feature
+++ b/test/features/summarylogs-exporter-registered-only.feature
@@ -52,6 +52,13 @@ Feature: Summary Logs - Registered Only Exporter
       | added.invalid  | 0     |                          |
       | added.included | 0     |                          |
       | added.excluded | 0     |                          |
+    And the summary log has the following reporting period loads
+      | Key                                                 | Value |
+      | openPeriodLoads.added.balanceAffecting.count        | 0     |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta | 0     |
+      | openPeriodLoads.added.nonBalanceAffecting.count     | 15    |
+      | openPeriodLoads.adjusted.balanceAffecting.count     | 0     |
+      | closedPeriodLoads.added.balanceAffecting.count      | 0     |
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'

--- a/test/features/summarylogs-exporter.feature
+++ b/test/features/summarylogs-exporter.feature
@@ -124,6 +124,13 @@ Feature: Summary Logs - Exporter
       | added.invalid  | 0     |        |
       | added.included | 0     |        |
       | added.excluded | 0     |        |
+    And the summary log has the following reporting period loads
+      | Key                                                 | Value |
+      | openPeriodLoads.added.balanceAffecting.count        | 2     |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta | 30    |
+      | openPeriodLoads.added.nonBalanceAffecting.count     | 2     |
+      | openPeriodLoads.adjusted.balanceAffecting.count     | 0     |
+      | closedPeriodLoads.added.balanceAffecting.count      | 0     |
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'
@@ -199,6 +206,15 @@ Feature: Summary Logs - Exporter
       | adjusted.invalid   | 0     |        |
       | adjusted.included  | 0     |        |
       | adjusted.excluded  | 0     |        |
+    And the summary log has the following reporting period loads
+      | Key                                                    | Value |
+      | openPeriodLoads.added.balanceAffecting.count           | 1     |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta    | 49    |
+      | openPeriodLoads.added.nonBalanceAffecting.count        | 1     |
+      | openPeriodLoads.adjusted.balanceAffecting.count        | 2     |
+      | openPeriodLoads.adjusted.balanceAffecting.tonnageDelta | 0     |
+      | openPeriodLoads.adjusted.nonBalanceAffecting.count     | 0     |
+      | closedPeriodLoads.added.balanceAffecting.count         | 0     |
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'
@@ -355,6 +371,14 @@ Feature: Summary Logs - Exporter
       | adjusted.invalid   | 0     |        |
       | adjusted.included  | 0     |        |
       | adjusted.excluded  | 0     |        |
+    And the summary log has the following reporting period loads
+      | Key                                                    | Value |
+      | openPeriodLoads.added.balanceAffecting.count           | 0     |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta    | 0     |
+      | openPeriodLoads.added.nonBalanceAffecting.count        | 1     |
+      | openPeriodLoads.adjusted.balanceAffecting.count        | 2     |
+      | openPeriodLoads.adjusted.balanceAffecting.tonnageDelta | 0     |
+      | closedPeriodLoads.added.balanceAffecting.count         | 0     |
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'

--- a/test/features/summarylogs-reprocessor-input.feature
+++ b/test/features/summarylogs-reprocessor-input.feature
@@ -51,6 +51,13 @@ Feature: Summary Logs - Reprocessor on Input
       | added.invalid  | 0     |        |
       | added.included | 1     | 5000   |
       | added.excluded | 0     |        |
+    And the summary log has the following reporting period loads
+      | Key                                                 | Value  |
+      | openPeriodLoads.added.balanceAffecting.count        | 3      |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta | 361.62 |
+      | openPeriodLoads.added.nonBalanceAffecting.count     | 2      |
+      | openPeriodLoads.adjusted.balanceAffecting.count     | 0      |
+      | closedPeriodLoads.added.balanceAffecting.count      | 0      |
 
     When I submit the uploaded summary log and initiate a new upload at the same time
     Then the summary log submission succeeds
@@ -168,6 +175,15 @@ Feature: Summary Logs - Reprocessor on Input
       | adjusted.invalid   | 0     |        |
       | adjusted.included  | 0     |        |
       | adjusted.excluded  | 0     |        |
+    And the summary log has the following reporting period loads
+      | Key                                                    | Value |
+      | openPeriodLoads.added.balanceAffecting.count           | 1     |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta    | -50   |
+      | openPeriodLoads.added.nonBalanceAffecting.count        | 4     |
+      | openPeriodLoads.adjusted.balanceAffecting.count        | 1     |
+      | openPeriodLoads.adjusted.balanceAffecting.tonnageDelta | 74.89 |
+      | openPeriodLoads.adjusted.nonBalanceAffecting.count     | 1     |
+      | closedPeriodLoads.added.balanceAffecting.count         | 0     |
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'
@@ -288,6 +304,13 @@ Feature: Summary Logs - Reprocessor on Input
       | added.invalid  | 0     |        |
       | added.included | 0     |        |
       | added.excluded | 1     | 5000   |
+    And the summary log has the following reporting period loads
+      | Key                                                 | Value |
+      | openPeriodLoads.added.balanceAffecting.count        | 0     |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta | 0     |
+      | openPeriodLoads.added.nonBalanceAffecting.count     | 2     |
+      | openPeriodLoads.adjusted.balanceAffecting.count     | 0     |
+      | closedPeriodLoads.added.balanceAffecting.count      | 0     |
 
     When I submit the uploaded summary log
     Then the summary log submission succeeds

--- a/test/features/summarylogs-reprocessor-output.feature
+++ b/test/features/summarylogs-reprocessor-output.feature
@@ -78,6 +78,13 @@ Feature: Summary Logs - Reprocessor on Output
       | added.invalid  | 0     |           |
       | added.included | 0     |           |
       | added.excluded | 0     |           |
+    And the summary log has the following reporting period loads
+      | Key                                                 | Value |
+      | openPeriodLoads.added.balanceAffecting.count        | 1     |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta | 3     |
+      | openPeriodLoads.added.nonBalanceAffecting.count     | 5     |
+      | openPeriodLoads.adjusted.balanceAffecting.count     | 0     |
+      | closedPeriodLoads.added.balanceAffecting.count      | 0     |
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'
@@ -167,6 +174,15 @@ Feature: Summary Logs - Reprocessor on Output
       | adjusted.invalid   | 0     |           |
       | adjusted.included  | 0     |           |
       | adjusted.excluded  | 0     |           |
+    And the summary log has the following reporting period loads
+      | Key                                                    | Value |
+      | openPeriodLoads.added.balanceAffecting.count           | 1     |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta    | 4.25  |
+      | openPeriodLoads.added.nonBalanceAffecting.count        | 3     |
+      | openPeriodLoads.adjusted.balanceAffecting.count        | 1     |
+      | openPeriodLoads.adjusted.balanceAffecting.tonnageDelta | 2     |
+      | openPeriodLoads.adjusted.nonBalanceAffecting.count     | 0     |
+      | closedPeriodLoads.added.balanceAffecting.count         | 0     |
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'

--- a/test/features/summarylogs-reprocessor-registered-only.feature
+++ b/test/features/summarylogs-reprocessor-registered-only.feature
@@ -46,6 +46,13 @@ Feature: Summary Logs - Registered Only Reprocessor
       | added.invalid  | 0     |                           |
       | added.included | 0     |                           |
       | added.excluded | 0     |                           |
+    And the summary log has the following reporting period loads
+      | Key                                                 | Value |
+      | openPeriodLoads.added.balanceAffecting.count        | 0     |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta | 0     |
+      | openPeriodLoads.added.nonBalanceAffecting.count     | 10    |
+      | openPeriodLoads.adjusted.balanceAffecting.count     | 0     |
+      | closedPeriodLoads.added.balanceAffecting.count      | 0     |
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'

--- a/test/features/summarylogs-validation.feature
+++ b/test/features/summarylogs-validation.feature
@@ -159,3 +159,10 @@ Feature: Summary Logs validation tests
       | added.invalid  | 0     |        |
       | added.included | 1     | 5000   |
       | added.excluded | 0     |        |
+    And the summary log has the following reporting period loads
+      | Key                                                 | Value  |
+      | openPeriodLoads.added.balanceAffecting.count        | 2      |
+      | openPeriodLoads.added.balanceAffecting.tonnageDelta | 309.99 |
+      | openPeriodLoads.added.nonBalanceAffecting.count     | 2      |
+      | openPeriodLoads.adjusted.balanceAffecting.count     | 0      |
+      | closedPeriodLoads.added.balanceAffecting.count      | 0      |

--- a/test/step-definitions/summarylogs.steps.js
+++ b/test/step-definitions/summarylogs.steps.js
@@ -251,9 +251,6 @@ Then(
     const expectedData = dataTable.hashes()
     const loadsByReportingPeriod = this.responseData.loadsByReportingPeriod
 
-    // eslint-disable-next-line no-unused-expressions
-    expect(loadsByReportingPeriod).to.not.be.undefined
-
     for (const expectation of expectedData) {
       const actual = expectation.Key.split('.').reduce(
         (acc, key) => acc?.[key],

--- a/test/step-definitions/summarylogs.steps.js
+++ b/test/step-definitions/summarylogs.steps.js
@@ -245,6 +245,29 @@ Then(
   }
 )
 
+Then(
+  'the summary log has the following reporting period loads',
+  async function (dataTable) {
+    const expectedData = dataTable.hashes()
+    const loadsByReportingPeriod = this.responseData.loadsByReportingPeriod
+
+    // eslint-disable-next-line no-unused-expressions
+    expect(loadsByReportingPeriod).to.not.be.undefined
+
+    for (const expectation of expectedData) {
+      const actual = expectation.Key.split('.').reduce(
+        (acc, key) => acc?.[key],
+        loadsByReportingPeriod
+      )
+
+      expect(actual).to.equal(
+        Number(expectation.Value),
+        `Failed at ${expectation.Key}: expected ${expectation.Value}, got ${actual}`
+      )
+    }
+  }
+)
+
 Then('the summary log has the following loads', async function (dataTable) {
   const expectedLoads = dataTable.hashes()
 


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)
## What

The summary log GET endpoint now returns `loadsByReportingPeriod` on validated logs (backend #1300). This adds journey-test assertions for that field across the validation-lifecycle scenarios, so the payload is confirmed to survive end to end through the real MongoDB repository and queue consumer pipeline.

## Why

The field was previously called `loadsByPeriodStatus` and has since been renamed and reshaped. The journey suite had no coverage for it, so a regression in classification or serialisation would go unnoticed at the integration boundary.

## Changes

- New step: `the summary log has the following reporting period loads`, which validates the field via dot-path traversal (exact value, `present`, or numeric match).
- Assertions added to all six validation-lifecycle feature files: exporter, reprocessor input/output, registered-only exporter/reprocessor, and the validation feature.

## Payload shape

```
loadsByReportingPeriod
  openPeriodLoads / closedPeriodLoads
    added / adjusted
      balanceAffecting { count, tonnageDelta }
      nonBalanceAffecting { count }
```

Both periods are always present in the response, so empty buckets are asserted as `count` 0 rather than null. First uploads assert the exact `balanceAffecting.tonnageDelta` matching the waste balance; adjustment uploads assert structural presence of the populated buckets.

## Testing

- `npm run lint`, `npm run format:check`, and `cucumber-js --dry-run` all pass.
- Runtime values are exercised by the journey suite in CI.


[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ