### PR TITLE
PAE-250: Fix tmp directory traversal vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": ">=24.15.0 <25"
+        "node": ">=24.16.0 <25"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -8392,9 +8392,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "undici": "7.24.5"
   },
   "overrides": {
-    "uuid": "14.0.0"
+    "uuid": "14.0.0",
+    "tmp": "0.2.7"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Fixes a high-severity vulnerability flagged by Snyk in the test tooling.

- Pins `tmp` to 0.2.7 via an override, clearing SNYK-JS-TMP-17315641 (directory traversal). `tmp` is pulled in transitively through `exceljs`.

A stale `uuid` override and the existing `SNYK-JS-INFLIGHT-6095116` ignore were both checked and confirmed still needed, so they are retained. After the change `snyk test` finds no vulnerable paths and `npm audit` reports no vulnerabilities.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ