### PR TITLE
PAE-1554: add submissionNumber to all report step definitions and feature files

### DIFF
--- a/test/features/authorisation.feature
+++ b/test/features/authorisation.feature
@@ -9,7 +9,7 @@ Feature: Authorisation tests for non-write service maintainers
     Then I should receive a 403 error response 'Insufficient scope'
 
   Scenario: Read only user does not have access to unsubmit report
-    When I unsubmit the 'monthly' report for the year 2026 and period 1
+    When I unsubmit the 'monthly' report for the year 2026, period 1 and submissionNumber 1
     Then I should receive a 403 error response 'Insufficient scope'
 
   Scenario: Read only user does not have access to update organisations
@@ -38,7 +38,7 @@ Feature: Authorisation tests for non-write service maintainers
       Then I should receive a 403 error response 'Insufficient scope'
 
     Scenario: Support only user does not have access to unsubmit report
-      When I unsubmit the 'monthly' report for the year 2026 and period 1
+      When I unsubmit the 'monthly' report for the year 2026, period 1 and submissionNumber 1
       Then I should receive a 403 error response 'Insufficient scope'
 
     Scenario: Support only user does not have access to update organisations

--- a/test/features/public-register.feature
+++ b/test/features/public-register.feature
@@ -30,10 +30,10 @@ Feature: Public register endpoint
     When I submit the uploaded summary log
     Then the summary log submission succeeds
 
-    When I create the 'monthly' report for the year 2026 and period 1
+    When I create the 'monthly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully created
 
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | tonnageRecycled    | 100.5 |
       | tonnageNotRecycled | 20    |
       | prnRevenue         | 123.4 |
@@ -46,9 +46,9 @@ Feature: Public register endpoint
       | prn.totalRevenue                     | 123.4 |
       | prn.freeTonnage                      | 0     |
 
-    When I update the 'monthly' report for the year 2026 and period 1 with status 'ready_to_submit' and version 2
+    When I update the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with status 'ready_to_submit' and version 2
     Then the report status is successfully updated
-    When I update the 'monthly' report for the year 2026 and period 1 with status 'submitted' and version 3
+    When I update the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with status 'submitted' and version 3
     Then the report status is successfully updated
 
     Given I am logged in as a service maintainer

--- a/test/features/reports-patch-reprocessor.feature
+++ b/test/features/reports-patch-reprocessor.feature
@@ -32,11 +32,11 @@ Feature: Reports PATCH endpoint for Reprocessor organisations
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'
 
-    When I create the 'monthly' report for the year 2026 and period 1
+    When I create the 'monthly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully created
 
   Scenario: PATCH with tonnageRecycled succeeds for a reprocessor report
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | tonnageRecycled | 100.5 |
     Then the report patch succeeds
     And the patched report contains the following information
@@ -44,7 +44,7 @@ Feature: Reports PATCH endpoint for Reprocessor organisations
       | recyclingActivity.tonnageRecycled | 100.5 |
 
   Scenario: PATCH with tonnageNotRecycled succeeds for a reprocessor report
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | tonnageNotRecycled | 20 |
     Then the report patch succeeds
     And the patched report contains the following information
@@ -52,7 +52,7 @@ Feature: Reports PATCH endpoint for Reprocessor organisations
       | recyclingActivity.tonnageNotRecycled | 20    |
 
   Scenario: PATCH with both tonnageRecycled and tonnageNotRecycled succeeds
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | tonnageRecycled    | 100 |
       | tonnageNotRecycled | 20  |
     Then the report patch succeeds
@@ -62,12 +62,12 @@ Feature: Reports PATCH endpoint for Reprocessor organisations
       | recyclingActivity.tonnageNotRecycled | 20    |
 
   Scenario: PATCH with negative tonnageRecycled returns 422
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | tonnageRecycled | -1 |
     Then I should receive a 422 error response '"tonnageRecycled" must be greater than or equal to 0'
 
   Scenario: PATCH with all fields succeeds (with submission and unsubmission) for a reprocessor report
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | tonnageRecycled    | 100.5 |
       | tonnageNotRecycled | 20    |
       | prnRevenue         | 123.4 |
@@ -79,10 +79,10 @@ Feature: Reports PATCH endpoint for Reprocessor organisations
       | recyclingActivity.tonnageNotRecycled | 20    |
       | prn.totalRevenue                     | 123.4 |
       | prn.freeTonnage                      | 0     |
-    When I update the 'monthly' report for the year 2026 and period 1 with status 'ready_to_submit' and version 2
+    When I update the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with status 'ready_to_submit' and version 2
     Then the report status is successfully updated
-    When I update the 'monthly' report for the year 2026 and period 1 with status 'submitted' and version 3
+    When I update the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with status 'submitted' and version 3
     Then the report status is successfully updated
 
-    When I unsubmit the 'monthly' report for the year 2026 and period 1
+    When I unsubmit the 'monthly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully unsubmitted

--- a/test/features/reports-patch.feature
+++ b/test/features/reports-patch.feature
@@ -32,11 +32,11 @@ Feature: Reports PATCH endpoint
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'
 
-    When I create the 'monthly' report for the year 2026 and period 1
+    When I create the 'monthly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully created
 
   Scenario: PATCH with prnRevenue succeeds for an in_progress report
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | prnRevenue | 1576.12 |
     Then the report patch succeeds
     And the patched report contains the following information
@@ -44,7 +44,7 @@ Feature: Reports PATCH endpoint
       | prn.totalRevenue | 1576.12 |
 
   Scenario: PATCH with freeTonnage succeeds for an in_progress report
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | freeTonnage | 0 |
     Then the report patch succeeds
     And the patched report contains the following information
@@ -52,7 +52,7 @@ Feature: Reports PATCH endpoint
       | prn.freeTonnage | 0     |
 
   Scenario: PATCH with both prnRevenue and freeTonnage succeeds
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | prnRevenue  | 1576.12 |
       | freeTonnage | 0       |
     Then the report patch succeeds
@@ -62,21 +62,21 @@ Feature: Reports PATCH endpoint
       | prn.freeTonnage  | 0       |
 
   Scenario: PATCH with negative prnRevenue returns 422
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | prnRevenue | -1 |
     Then I should receive a 422 error response '"prnRevenue" must be greater than or equal to 0'
 
   Scenario: PATCH with empty body returns 422
-    When I patch the 'monthly' report for the year 2026 and period 1 with empty body
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with empty body
     Then I should receive a 422 error response '"value" must have at least 1 key'
 
   Scenario: PATCH for a non-existent period returns 404
-    When I patch the 'monthly' report for the year 2026 and period 12 with
+    When I patch the 'monthly' report for the year 2026, period 12 and submissionNumber 1 with
       | prnRevenue | 100 |
     Then I should receive a 404 error response 'No report found for monthly period 12 of 2026'
 
   Scenario: Existing supportingInformation PATCH still works unchanged
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | supportingInformation | Test supporting information |
     Then the report patch succeeds
     And the patched report contains the following information
@@ -84,11 +84,11 @@ Feature: Reports PATCH endpoint
       | supportingInformation | Test supporting information |
 
   Scenario: GET after PATCH returns updated PRN data
-    When I patch the 'monthly' report for the year 2026 and period 1 with
+    When I patch the 'monthly' report for the year 2026, period 1 and submissionNumber 1 with
       | prnRevenue  | 3000 |
       | freeTonnage | 0    |
     Then the report patch succeeds
-    When I retrieve the 'monthly' report for the year 2026 and period 1
+    When I retrieve the 'monthly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully retrieved
     And the report contains the following information
       | Key              | Value |

--- a/test/features/summarylogs-exporter-registered-only.feature
+++ b/test/features/summarylogs-exporter-registered-only.feature
@@ -63,10 +63,10 @@ Feature: Summary Logs - Registered Only Exporter
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'
 
-    When I create the 'quarterly' report for the year 2026 and period 1
+    When I create the 'quarterly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully created
 
-    When I retrieve the 'quarterly' report for the year 2026 and period 1
+    When I retrieve the 'quarterly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully retrieved
     And the report contains the following information
       | Key                 | Value    |

--- a/test/features/summarylogs-exporter.feature
+++ b/test/features/summarylogs-exporter.feature
@@ -233,7 +233,7 @@ Feature: Summary Logs - Exporter
       | {{summaryLogAccId}} | 79     | 79              |
 
     # Sent On sheet contribute to the report
-    When I retrieve the 'monthly' report for the year 2026 and period 1
+    When I retrieve the 'monthly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully retrieved
     And the report contains the following information
       | Key                                    | Value    |
@@ -245,7 +245,7 @@ Feature: Summary Logs - Exporter
       | details.material                       | paper    |
 
     # RowId 1002, 1003 of the adjustments contribute to the report
-    When I retrieve the 'monthly' report for the year 2025 and period 1
+    When I retrieve the 'monthly' report for the year 2025, period 1 and submissionNumber 1
     Then the report is successfully retrieved
     And the report contains the following information
       | Key                                    | Value    |

--- a/test/features/summarylogs-reprocessor-output.feature
+++ b/test/features/summarylogs-reprocessor-output.feature
@@ -205,7 +205,7 @@ Feature: Summary Logs - Reprocessor on Output
       | AccreditationId     | Amount | AvailableAmount |
       | {{summaryLogAccId}} | 9.25   | 9.25            |
 
-    When I retrieve the 'monthly' report for the year 2026 and period 1
+    When I retrieve the 'monthly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully retrieved
     And the report contains the following information
       | Key                                 | Value       |

--- a/test/features/summarylogs-reprocessor-registered-only.feature
+++ b/test/features/summarylogs-reprocessor-registered-only.feature
@@ -56,7 +56,7 @@ Feature: Summary Logs - Registered Only Reprocessor
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'
-    When I retrieve the 'quarterly' report for the year 2026 and period 1
+    When I retrieve the 'quarterly' report for the year 2026, period 1 and submissionNumber 1
     Then the report is successfully retrieved
     And the report contains the following information
       | Key                                 | Value                       |

--- a/test/step-definitions/reporting.steps.js
+++ b/test/step-definitions/reporting.steps.js
@@ -3,10 +3,10 @@ import { authClient, defraIdStub, eprBackendAPI } from '../support/hooks.js'
 import { expect } from 'chai'
 
 When(
-  'I retrieve the {string} report for the year {int} and period {int}',
-  async function (cadence, year, period) {
+  'I retrieve the {string} report for the year {int}, period {int} and submissionNumber {int}',
+  async function (cadence, year, period, submissionNumber) {
     this.response = await eprBackendAPI.get(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`,
       defraIdStub.authHeader(this.userId)
     )
   }
@@ -42,10 +42,10 @@ Then(
 )
 
 When(
-  'I create the {string} report for the year {int} and period {int}',
-  async function (cadence, year, period) {
+  'I create the {string} report for the year {int}, period {int} and submissionNumber {int}',
+  async function (cadence, year, period, submissionNumber) {
     this.response = await eprBackendAPI.post(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`,
       '',
       defraIdStub.authHeader(this.userId)
     )
@@ -57,8 +57,8 @@ Then('the report is successfully created', async function () {
 })
 
 When(
-  'I patch the {string} report for the year {int} and period {int} with',
-  async function (cadence, year, period, dataTable) {
+  'I patch the {string} report for the year {int}, period {int} and submissionNumber {int} with',
+  async function (cadence, year, period, submissionNumber, dataTable) {
     const fields = dataTable.rowsHash()
     const payload = {}
 
@@ -67,7 +67,7 @@ When(
     }
 
     this.response = await eprBackendAPI.patch(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`,
       JSON.stringify(payload),
       defraIdStub.authHeader(this.userId)
     )
@@ -75,10 +75,10 @@ When(
 )
 
 When(
-  'I patch the {string} report for the year {int} and period {int} with empty body',
-  async function (cadence, year, period) {
+  'I patch the {string} report for the year {int}, period {int} and submissionNumber {int} with empty body',
+  async function (cadence, year, period, submissionNumber) {
     this.response = await eprBackendAPI.patch(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`,
       JSON.stringify({}),
       defraIdStub.authHeader(this.userId)
     )
@@ -118,10 +118,10 @@ Then(
 )
 
 When(
-  'I update the {string} report for the year {int} and period {int} with status {string} and version {int}',
-  async function (cadence, year, period, status, version) {
+  'I update the {string} report for the year {int}, period {int} and submissionNumber {int} with status {string} and version {int}',
+  async function (cadence, year, period, submissionNumber, status, version) {
     this.response = await eprBackendAPI.post(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/status`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/status`,
       JSON.stringify({ status, version }),
       defraIdStub.authHeader(this.userId)
     )
@@ -139,10 +139,10 @@ Then('the report is successfully unsubmitted', async function () {
 })
 
 When(
-  'I unsubmit the {string} report for the year {int} and period {int}',
-  async function (cadence, year, period) {
+  'I unsubmit the {string} report for the year {int}, period {int} and submissionNumber {int}',
+  async function (cadence, year, period, submissionNumber) {
     this.response = await eprBackendAPI.post(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/unsubmit`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/unsubmit`,
       '',
       authClient.authHeader()
     )

--- a/test/step-definitions/reporting.steps.js
+++ b/test/step-definitions/reporting.steps.js
@@ -6,7 +6,7 @@ When(
   'I retrieve the {string} report for the year {int}, period {int} and submissionNumber {int}',
   async function (cadence, year, period, submissionNumber) {
     this.response = await eprBackendAPI.get(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`,
       defraIdStub.authHeader(this.userId)
     )
   }
@@ -45,7 +45,7 @@ When(
   'I create the {string} report for the year {int}, period {int} and submissionNumber {int}',
   async function (cadence, year, period, submissionNumber) {
     this.response = await eprBackendAPI.post(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`,
       '',
       defraIdStub.authHeader(this.userId)
     )
@@ -67,7 +67,7 @@ When(
     }
 
     this.response = await eprBackendAPI.patch(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`,
       JSON.stringify(payload),
       defraIdStub.authHeader(this.userId)
     )
@@ -78,7 +78,7 @@ When(
   'I patch the {string} report for the year {int}, period {int} and submissionNumber {int} with empty body',
   async function (cadence, year, period, submissionNumber) {
     this.response = await eprBackendAPI.patch(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}`,
       JSON.stringify({}),
       defraIdStub.authHeader(this.userId)
     )
@@ -121,7 +121,7 @@ When(
   'I update the {string} report for the year {int}, period {int} and submissionNumber {int} with status {string} and version {int}',
   async function (cadence, year, period, submissionNumber, status, version) {
     this.response = await eprBackendAPI.post(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/status`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}/status`,
       JSON.stringify({ status, version }),
       defraIdStub.authHeader(this.userId)
     )
@@ -142,7 +142,7 @@ When(
   'I unsubmit the {string} report for the year {int}, period {int} and submissionNumber {int}',
   async function (cadence, year, period, submissionNumber) {
     this.response = await eprBackendAPI.post(
-      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/${submissionNumber}/unsubmit`,
+      `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}/unsubmit`,
       '',
       authClient.authHeader()
     )


### PR DESCRIPTION
Ticket: [PAE-1554](https://eaflood.atlassian.net/browse/PAE-1554)
Update all reporting step definitions and feature files to include submissionNumber as an additional parameter, matching the backend API route change that now requires submissionNumber in the path for all report operations.

[PAE-1554]: https://eaflood.atlassian.net/browse/PAE-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ