### PR TITLE
PAE-250: Fix tmp directory traversal vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8392,9 +8392,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "undici": "7.24.5"
   },
   "overrides": {
+    "tmp": "0.2.7",
     "uuid": "14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ticket: [PAE-250](https://eaflood.atlassian.net/browse/PAE-250)
Addresses a tmp vulnerability surfaced by Snyk in this backend journey-test suite.

- **tmp** (high) — a symlink could be used to write outside the intended temporary directory (SNYK-JS-TMP-17315641). The vulnerable copy is pulled in transitively through `exceljs`, which has not yet widened its range to the patched release. An `overrides` entry pins tmp to 0.2.7.

The existing `uuid` override and the `SNYK-JS-INFLIGHT-6095116` Snyk ignore were each tested for staleness and both are still required.

[PAE-250]: https://eaflood.atlassian.net/browse/PAE-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ