### PR TITLE
PAE-1567: Pin auth stub images and drop floating-tag override

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -112,7 +112,7 @@ services:
       - cdp-tenant
 
   entra-stub:
-    image: defradigital/epr-re-ex-entra-stub:latest
+    image: defradigital/epr-re-ex-entra-stub:0.66.0
     ports:
       - 3010:3010
     environment:
@@ -126,7 +126,7 @@ services:
       - cdp-tenant
 
   defra-id-stub:
-    image: defradigital/cdp-defra-id-stub:${DEFRA_ID_STUB_VERSION:-latest}
+    image: defradigital/cdp-defra-id-stub:0.34.0
     ports:
       - '3200:3200'
     depends_on:


### PR DESCRIPTION
Ticket: [PAE-1567](https://eaflood.atlassian.net/browse/PAE-1567)
The journey-test compose floated both auth stub images: `cdp-defra-id-stub` via the `${DEFRA_ID_STUB_VERSION:-latest}` override env var, and `epr-re-ex-entra-stub` on `:latest`. When `cdp-defra-id-stub:latest` was republished as 0.35.0 it broke the Defra ID org-linking auth flow and turned this suite red (backend 500 on the org-linking setup step), blocking unrelated in-flight PRs.

This pins `cdp-defra-id-stub` to the last-good `0.34.0` and `epr-re-ex-entra-stub` to the current published `0.66.0`, and removes the `${DEFRA_ID_STUB_VERSION:-latest}` override env var. Both images now use bare pinned tags like every other image in the compose file.

Renovate's `docker-compose` manager (already enabled in `renovate.json`) tracks bare pinned tags — as it does for `mongo`, `redis`, and `cdp-uploader` — so the stubs now get bumped through the normal dependency-update flow instead of silently moving under `:latest`.

[PAE-1567]: https://eaflood.atlassian.net/browse/PAE-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ