### PR TITLE
PAE-1541: Assert per-row detail in loadsByReportingPeriod journey tests

### DIFF
--- a/test/features/summarylogs-reprocessor-input.feature
+++ b/test/features/summarylogs-reprocessor-input.feature
@@ -184,6 +184,17 @@ Feature: Summary Logs - Reprocessor on Input
       | openPeriodLoads.adjusted.balanceAffecting.tonnageDelta | 74.89 |
       | openPeriodLoads.adjusted.nonBalanceAffecting.count     | 1     |
       | closedPeriodLoads.added.balanceAffecting.count         | 0     |
+    # Each period bucket lists its rows with their identity, exclusion reason
+    # codes and the signed tonnage the leg moved: an included load carries no
+    # codes and its balance contribution, an excluded load carries the reason it
+    # was kept out (PRNs issued, missing field) and a zero delta.
+    And the reporting period buckets list the following rows
+      | Bucket                                       | RowId | WasteRecordType | ExclusionReasons       | TonnageDelta |
+      | openPeriodLoads.added.balanceAffecting       | 5001  | sentOn          |                        | -50          |
+      | openPeriodLoads.added.nonBalanceAffecting    | 1004  | received        | PRN_ISSUED             | 0            |
+      | openPeriodLoads.added.nonBalanceAffecting    | 1005  | received        | MISSING_REQUIRED_FIELD | 0            |
+      | openPeriodLoads.adjusted.balanceAffecting    | 1001  | received        |                        | 74.89        |
+      | openPeriodLoads.adjusted.nonBalanceAffecting | 1002  | received        | MISSING_REQUIRED_FIELD | 0            |
     When I submit the uploaded summary log
     Then the summary log submission succeeds
     And the summary log submission status is 'submitted'

--- a/test/step-definitions/summarylogs.steps.js
+++ b/test/step-definitions/summarylogs.steps.js
@@ -265,6 +265,44 @@ Then(
   }
 )
 
+Then(
+  'the reporting period buckets list the following rows',
+  async function (dataTable) {
+    const expectedRows = dataTable.hashes()
+    const loadsByReportingPeriod = this.responseData.loadsByReportingPeriod
+
+    for (const expected of expectedRows) {
+      const bucket = expected.Bucket.split('.').reduce(
+        (acc, key) => acc?.[key],
+        loadsByReportingPeriod
+      )
+
+      const actualRow = bucket?.rows?.find(
+        (row) => row.rowId === expected.RowId
+      )
+
+      if (!actualRow) {
+        expect.fail(
+          `Expected row ${expected.RowId} in bucket ${expected.Bucket} but found rows: ${JSON.stringify(bucket?.rows)}`
+        )
+      }
+
+      expect(actualRow.wasteRecordType).to.equal(
+        expected.WasteRecordType,
+        `Failed wasteRecordType at ${expected.Bucket} row ${expected.RowId}`
+      )
+      expect(actualRow.exclusionReasons.join(',')).to.equal(
+        expected.ExclusionReasons,
+        `Failed exclusionReasons at ${expected.Bucket} row ${expected.RowId}`
+      )
+      expect(actualRow.tonnageDelta).to.equal(
+        Number(expected.TonnageDelta),
+        `Failed tonnageDelta at ${expected.Bucket} row ${expected.RowId}`
+      )
+    }
+  }
+)
+
 Then('the summary log has the following loads', async function (dataTable) {
   const expectedLoads = dataTable.hashes()
 


### PR DESCRIPTION
Ticket: [PAE-1541](https://eaflood.atlassian.net/browse/PAE-1541)

The behaviour in epr-backend's `main` already matches these enhancements.

## What

Adds journey-test coverage for the per-row detail now carried on every `loadsByReportingPeriod` bucket. A new step, `the reporting period buckets list the following rows`, asserts each listed row's `rowId`, `wasteRecordType`, `exclusionReasons` and `tonnageDelta` by bucket path. It is wired into the reprocessor-input scenario, covering:

- An included load: empty `exclusionReasons` and the signed tonnage its leg moved (for example `5001` at `-50`, `1001` at `74.89`).
- Excluded loads: the reason the load was kept out of the waste balance (`PRN_ISSUED`, `MISSING_REQUIRED_FIELD`) and a zero `tonnageDelta`.

## Why

The backend now surfaces, per row, the identity, exclusion reason codes and the signed balance contribution on each open/closed period bucket (added in epr-backend `loadsByReportingPeriod`). These power the check-page expandable row lists and the "reduced/added to your waste balance" copy on the frontend. Existing journey coverage only asserts the bucket-level counts and aggregate `tonnageDelta`, so the per-row contract was unverified end to end. This exercises it through the real upload and GET path, guarding both the field shape and the classification that produces each row's reason codes and delta.

[PAE-1541]: https://eaflood.atlassian.net/browse/PAE-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ