### PR TITLE
PAE-1576: Match waste record rowId as string identity

### DIFF
--- a/test/step-definitions/summarylogs.steps.js
+++ b/test/step-definitions/summarylogs.steps.js
@@ -519,7 +519,7 @@ Then(
           (record) =>
             record.organisationId === expectedOrgId &&
             record.registrationId === expectedRegId &&
-            record.rowId === parseInt(expectedWasteRecord.RowId) &&
+            record.rowId === expectedWasteRecord.RowId &&
             record.type === expectedWasteRecord.Type
         )
 
@@ -587,7 +587,7 @@ Then(
           (record) =>
             record.organisationId === expectedOrgId &&
             record.registrationId === expectedRegId &&
-            record.rowId === parseInt(expectedWasteRecord.RowId) &&
+            record.rowId === expectedWasteRecord.RowId &&
             record.type === expectedWasteRecord.Type
         )
 


### PR DESCRIPTION
Ticket: [PAE-1576](https://eaflood.atlassian.net/browse/PAE-1576)

The waste-record assertion step matched expected rows with `record.rowId === parseInt(expectedWasteRecord.RowId)`, coercing the expected identifier to a number. [epr-backend#1349](https://github.com/DEFRA/epr-backend/pull/1349) makes `rowId` a string — a row ID is an identifier, not a quantity, so nothing relies on it being numeric — which made the matcher's numeric comparison fail to find any record (`"1000" === 1000` is false).

Both waste-record matchers now compare the row ID as the string identity it is (`record.rowId === expectedWasteRecord.RowId`), matching the existing string comparison already used elsewhere in this step file.

This change is paired with epr-backend#1349 and must merge in lockstep: that PR's CI runs against this branch (matched by name), and once epr-backend merges, `main` here must carry this fix or the matcher breaks against backend `main`.

Jira: https://eaflood.atlassian.net/browse/PAE-1576


[PAE-1576]: https://eaflood.atlassian.net/browse/PAE-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ