### PR TITLE
PAE-1476: Pass submissionDeclaredBy for submitted status transitions

### DIFF
--- a/test/step-definitions/reporting.steps.js
+++ b/test/step-definitions/reporting.steps.js
@@ -120,9 +120,13 @@ Then(
 When(
   'I update the {string} report for the year {int}, period {int} and submissionNumber {int} with status {string} and version {int}',
   async function (cadence, year, period, submissionNumber, status, version) {
+    const payload = { status, version }
+    if (status === 'submitted') {
+      payload.submissionDeclaredBy = 'Test User'
+    }
     this.response = await eprBackendAPI.post(
       `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/${year}/${cadence}/${period}/submissions/${submissionNumber}/status`,
-      JSON.stringify({ status, version }),
+      JSON.stringify(payload),
       defraIdStub.authHeader(this.userId)
     )
   }


### PR DESCRIPTION
Ticket: [PAE-1476](https://eaflood.atlassian.net/browse/PAE-1476)
## Summary

- Updates the `I update the report` step definition to include `submissionDeclaredBy` in the payload when the status is `submitted`, as required by the BE route change in PAE-1476

## Context

PAE-1476 added a mandatory `submissionDeclaredBy` field to the report status route for `submitted` transitions. This broke the Cucumber steps in `public-register.feature` and `reports-patch-reprocessor.feature` which call `PATCH /status` with `submitted` without that field.


[PAE-1476]: https://eaflood.atlassian.net/browse/PAE-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ