### PR TITLE
PAE-1556 reflect updated status codes on org linking edge-cases

### DIFF
--- a/test/features/authentication.feature
+++ b/test/features/authentication.feature
@@ -29,7 +29,7 @@ Feature: Authentication tests
     Then I should receive a 409 error response 'Organisation is not in a linkable state'
     And the following messages appear in the log
       | Log Level | Event Action | Message                                     |
-      | warn      | auth_failed  | Organisation is not in a linkable state |
+      | warn      | request_failure  | Organisation is not in a linkable state |
 
   Scenario: Should not allow re-linking of linked organisation
     When the User is linked to the recently migrated organisation

--- a/test/features/authentication.feature
+++ b/test/features/authentication.feature
@@ -26,14 +26,14 @@ Feature: Authentication tests
     When I register and authorise a new User with email 'test123456@testuserz.com'
 
     When the User is linked to the recently migrated organisation
-    Then I should receive a 401 error response 'user is not authorised to link organisation'
+    Then I should receive a 409 error response 'Organisation is not in a linkable state'
     And the following messages appear in the log
       | Log Level | Event Action | Message                                     |
-      | warn      | auth_failed  | user is not authorised to link organisation |
+      | warn      | auth_failed  | Organisation is not in a linkable state |
 
   Scenario: Should not allow re-linking of linked organisation
     When the User is linked to the recently migrated organisation
-    Then I should receive a 409 error response 'Organisation is already linked'
+    Then I should receive a 409 error response 'Organisation is not in a linkable state'
 
   Scenario: Auth errors are logged when a different user tries to access a recently linked organisation
     When I register and authorise a new User with email 'anothertest123456@testuserz.com'


### PR DESCRIPTION
Ticket: [PAE-1556](https://eaflood.atlassian.net/browse/PAE-1556)
## Description

Update tests to reflect that some failure to link edge-cases now return `409` instead of `401`

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1556]: https://eaflood.atlassian.net/browse/PAE-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ