### PR TITLE
PAE-1675 update tests to reflect basic auth removal from some endpoints

### DIFF
--- a/test/features/basic-auth.feature
+++ b/test/features/basic-auth.feature
@@ -5,6 +5,7 @@ Feature: Basic auth tests for endpoints exposed to basic auth clients
     Given I create a linked and migrated organisation for the following
       | wasteProcessingType |
       | Reprocessor         |
+    And I use the default basic auth credentials
     When I request the recently migrated organisation via basic auth
     Then I should receive a valid organisations response for the recently migrated organisation
 

--- a/test/features/basic-auth.feature
+++ b/test/features/basic-auth.feature
@@ -1,13 +1,5 @@
 @basic_auth
-Feature: Basic auth tests for organisation retrieval endpoint
-
-  Scenario: Ensure that organisations endpoint returns a response when using basic auth
-    Given I use the default basic auth credentials
-    When I request the organisations with the following parameters via basic auth
-      | page | pageSize |
-      | 1    | 1        |
-    Then I should receive a valid organisations response
-    And I should receive 1 organisation in the response
+Feature: Basic auth tests for endpoints exposed to basic auth clients
 
   Scenario: Ensure that organisations (By ID) endpoint returns a response when using basic auth
     Given I create a linked and migrated organisation for the following
@@ -16,24 +8,10 @@ Feature: Basic auth tests for organisation retrieval endpoint
     When I request the recently migrated organisation via basic auth
     Then I should receive a valid organisations response for the recently migrated organisation
 
-  Scenario: Ensure that overseas site endpoint returns a response when using basic auth
-    Given I use the default basic auth credentials
-    When I request the overseas sites list via basic auth
-    Then I should receive a valid overseas site list response
-
   Scenario: Ensure that overseas site (By ID) endpoint returns a response (Not rejection) when using basic auth
     Given I use the default basic auth credentials
-    When I request the overseas sites by id 'invalidId' via basic auth
-    Then I should receive a 422 error response 'Invalid overseas site ID'
-    
-  Scenario: Ensure that organisations endpoint returns a rejection response when using incorrect credentials for basic auth
-    Given I use the following basic auth credentials
-      | username | password |
-      | invalid  | invalid  |
-    When I request the organisations with the following parameters via basic auth
-      | page | pageSize |
-      | 1    | 1        |
-    Then I should receive a 401 error response 'Missing authentication'
+    When I request the overseas sites for organisation 'unknownOrgId', registration 'someRegId' and accreditation 'someAccId' via basic auth
+    Then I should receive a 404 error response 'Organisation with id unknownOrgId not found'
 
   Scenario: Ensure that organisations (By ID) endpoint returns a rejection response when using incorrect credentials for basic auth
     Given I create a linked and migrated organisation for the following
@@ -45,16 +23,9 @@ Feature: Basic auth tests for organisation retrieval endpoint
     When I request the recently migrated organisation via basic auth
     Then I should receive a 401 error response 'Missing authentication'
 
-  Scenario: Ensure that overseas site endpoint returns a rejection response when using incorrect credentials for basic auth
-    Given I use the following basic auth credentials
-      | username | password |
-      | invalid  | invalid  |
-    When I request the overseas sites list via basic auth
-    Then I should receive a 401 error response 'Missing authentication'
-
   Scenario: Ensure that overseas site (By ID) endpoint returns a rejection response when using incorrect credentials for basic auth
     Given I use the following basic auth credentials
       | username | password |
       | invalid  | invalid  |
-    When I request the overseas sites by id 'invalidId' via basic auth
+    When I request the overseas sites for organisation 'unknownOrgId', registration 'someRegId' and accreditation 'someAccId' via basic auth
     Then I should receive a 401 error response 'Missing authentication'

--- a/test/features/basic-auth.feature
+++ b/test/features/basic-auth.feature
@@ -11,7 +11,7 @@ Feature: Basic auth tests for endpoints exposed to basic auth clients
   Scenario: Ensure that overseas site (By ID) endpoint returns a response (Not rejection) when using basic auth
     Given I use the default basic auth credentials
     When I request the overseas sites for organisation 'unknownOrgId', registration 'someRegId' and accreditation 'someAccId' via basic auth
-    Then I should receive a 422 error response 'Invalid organisation ID'
+    Then I should receive a 422 error response '"organisationId" with value "unknownOrgId" fails to match the required pattern: /^[a-f0-9]{24}$/. "registrationId" with value "someRegId" fails to match the required pattern: /^[a-f0-9]{24}$/. "accreditationId" with value "someAccId" fails to match the required pattern: /^[a-f0-9]{24}$/'
 
   Scenario: Ensure that organisations (By ID) endpoint returns a rejection response when using incorrect credentials for basic auth
     Given I create a linked and migrated organisation for the following

--- a/test/features/basic-auth.feature
+++ b/test/features/basic-auth.feature
@@ -11,7 +11,7 @@ Feature: Basic auth tests for endpoints exposed to basic auth clients
   Scenario: Ensure that overseas site (By ID) endpoint returns a response (Not rejection) when using basic auth
     Given I use the default basic auth credentials
     When I request the overseas sites for organisation 'unknownOrgId', registration 'someRegId' and accreditation 'someAccId' via basic auth
-    Then I should receive a 404 error response 'Organisation with id unknownOrgId not found'
+    Then I should receive a 422 error response 'Invalid organisation ID'
 
   Scenario: Ensure that organisations (By ID) endpoint returns a rejection response when using incorrect credentials for basic auth
     Given I create a linked and migrated organisation for the following

--- a/test/features/smoketests/basic-auth.feature
+++ b/test/features/smoketests/basic-auth.feature
@@ -1,19 +1,18 @@
 @smoketest
 Feature: Basic auth tests for organisation retrieval endpoint
 
-  Scenario: Ensure that organisations endpoint returns a response when using basic auth
+  Scenario: Ensure that organisations (By ID) endpoint returns a response when using basic auth
     Given I use the default basic auth credentials
-    When I request the organisations with the following parameters via basic auth
-      | page | pageSize |
-      | 1    | 1        |
+    When I request the recently migrated organisation via basic auth
     Then I should receive a valid organisations response
     And I should receive 1 organisation in the response
 
-  Scenario: Ensure that organisations endpoint returns a rejection response when using incorrect credentials for basic auth
-    Given I use the following basic auth credentials
+  Scenario: Ensure that organisations (By ID) endpoint returns a rejection response when using incorrect credentials for basic auth
+    Given I create a linked and migrated organisation for the following
+      | wasteProcessingType |
+      | Reprocessor         |
+    And I use the following basic auth credentials
       | username | password |
       | invalid  | invalid  |
-    When I request the organisations with the following parameters via basic auth
-      | page | pageSize |
-      | 1    | 1        |
+    When I request the recently migrated organisation via basic auth
     Then I should receive a 401 error response 'Missing authentication'

--- a/test/step-definitions/organisations.steps.js
+++ b/test/step-definitions/organisations.steps.js
@@ -339,18 +339,6 @@ When(
   }
 )
 
-When(
-  'I request the organisations with the following parameters via basic auth',
-  async function (dataTable) {
-    const [row] = dataTable.hashes()
-    const params = new URLSearchParams(row).toString()
-    this.response = await eprBackendAPI.get(
-      '/v1/organisations?' + params,
-      basicAuth.authHeader()
-    )
-  }
-)
-
 When('I request the recently migrated organisation', async function () {
   const orgId = this.orgResponseData?.referenceNumber
   this.response = await eprBackendAPI.get(

--- a/test/step-definitions/overseas-sites.steps.js
+++ b/test/step-definitions/overseas-sites.steps.js
@@ -473,7 +473,7 @@ When(
   'I request the overseas sites for organisation {string}, registration {string} and accreditation {string} via basic auth',
   async function (organisationId, registrationId, accreditationId) {
     this.response = await eprBackendAPI.get(
-      `/v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/overseas-sites`,
+      `/v1/organisations/${organisationId}/registrations/${registrationId}/accreditations/${accreditationId}/overseas-sites`,
       basicAuth.authHeader()
     )
   }

--- a/test/step-definitions/overseas-sites.steps.js
+++ b/test/step-definitions/overseas-sites.steps.js
@@ -469,19 +469,11 @@ When('I request the admin overseas sites list', async function () {
   )
 })
 
-When('I request the overseas sites list via basic auth', async function () {
-  this.adminOverseasSitesListBody = undefined
-  this.response = await eprBackendAPI.get(
-    '/v1/overseas-sites',
-    basicAuth.authHeader()
-  )
-})
-
 When(
-  'I request the overseas sites by id {string} via basic auth',
-  async function (id) {
+  'I request the overseas sites for organisation {string}, registration {string} and accreditation {string} via basic auth',
+  async function (organisationId, registrationId, accreditationId) {
     this.response = await eprBackendAPI.get(
-      `/v1/overseas-sites/${id}`,
+      `/v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/overseas-sites`,
       basicAuth.authHeader()
     )
   }


### PR DESCRIPTION
Ticket: [PAE-1675](https://eaflood.atlassian.net/browse/PAE-1675)
## Description

Removes tests for endpoints that no longer have basic auth

Add (missing) tests for basic auth protection of `'/v1/organisations/{organisationId}/registrations/{registrationId}/accreditations/{accreditationId}/overseas-sites'` endpoint

---

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1675]: https://eaflood.atlassian.net/browse/PAE-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ