### PR TITLE
PAE-1650: Add resubmission draft journey tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -190,6 +190,7 @@ services:
       DEFRA_ID_CLIENT_ID: 63983fc2-cfff-45bb-8ec2-959e21062b9a
       DEFRA_ID_OIDC_WELL_KNOWN_URL: http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/openid-configuration
       ENTRA_OIDC_WELL_KNOWN_CONFIGURATION_URL: http://entra-stub:3010/.well-known/openid-configuration
+      FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS: ${FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS:-true}
       FEATURE_FLAG_WASTE_RECORD_STATES: ${FEATURE_FLAG_WASTE_RECORD_STATES:-false}
       FEATURE_FLAG_DEV_ENDPOINTS: true
       GOVUK_NOTIFY_API_KEY: /run/secrets/govuk_notify_api_key

--- a/test/features/reports-resubmission.feature
+++ b/test/features/reports-resubmission.feature
@@ -1,0 +1,113 @@
+@reports
+@reports_resubmission
+Feature: Resubmission drafts for restated closed periods
+
+  # PAE-1650. When a summary log adjusts loads in a period whose report has
+  # already been submitted (a closed period), the backend flags the submitted
+  # report as requiring resubmission and permits a second submission to be
+  # drafted for that period. Requires FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS
+  # to be on in the backend under test (defaulted on in compose.yml).
+
+  Background:
+    Given I create a linked and migrated organisation for the following
+      | wasteProcessingType |
+      | Reprocessor         |
+
+    Given I am logged in as a service maintainer
+    When I update the recently migrated organisations data with the following data
+      | reprocessingType | regNumber        | accNumber | status   | validFrom  |
+      | input            | R25SR500030912PA | ACC123456 | approved | 2025-02-02 |
+    Then the organisations data update succeeds
+
+    When I register and authorise a User and link it to the recently migrated organisation
+
+    # First summary log creates the waste records, including loads received on
+    # 2025-08-01 (rows 1000-1002).
+    Given I have the following summary log upload data for summary log upload
+      | s3Bucket            | re-ex-summary-logs          |
+      | s3Key               | reprocessor-input-valid-key |
+      | fileId              | reprocessor-file-id         |
+      | filename            | reprocessor.xlsx            |
+      | fileStatus          | complete                    |
+      | accreditationNumber | ACC123456                   |
+      | registrationNumber  | R25SR500030912PA            |
+    When I initiate the summary log upload
+    Then the summary log upload initiation succeeds
+    When I submit the summary log upload completed
+    Then I should receive a summary log upload accepted response
+    And the summary log submission status is 'validated'
+    When I submit the uploaded summary log
+    Then the summary log submission succeeds
+    And the summary log submission status is 'submitted'
+
+    # Close August 2025 by submitting the period's report.
+    When I create the 'monthly' report for the year 2025, period 8 and submissionNumber 1
+    Then the report is successfully created
+    When I patch the 'monthly' report for the year 2025, period 8 and submissionNumber 1 with
+      | tonnageRecycled    | 100.5 |
+      | tonnageNotRecycled | 20    |
+      | prnRevenue         | 123.4 |
+      | freeTonnage        | 0     |
+    Then the report patch succeeds
+    When I update the 'monthly' report for the year 2025, period 8 and submissionNumber 1 with status 'ready_to_submit' and version 2
+    Then the report status is successfully updated
+    When I update the 'monthly' report for the year 2025, period 8 and submissionNumber 1 with status 'submitted' and version 3
+    Then the report status is successfully updated
+
+    # The second summary log adjusts row 1001 (received 2025-08-01), restating
+    # the now-closed August period; submitting it flags the submitted report as
+    # requiring resubmission.
+    Given I have the following summary log upload data for summary log upload
+      | s3Bucket   | re-ex-summary-logs                    |
+      | s3Key      | reprocessor-input-adjustments-key     |
+      | fileId     | reprocessor-input-adjustments-file-id |
+      | filename   | reprocessor-input-adjustments.xlsx    |
+      | fileStatus | complete                              |
+    When I initiate the summary log upload
+    Then the summary log upload initiation succeeds
+    When I submit the summary log upload completed
+    Then I should receive a summary log upload accepted response
+    And the summary log submission status is 'validated'
+    When I submit the uploaded summary log
+    Then the summary log submission succeeds
+    And the summary log submission status is 'submitted'
+
+  Scenario: A resubmission draft can be created and submitted for a restated closed period
+    # The flagged period yields two calendar items: the submitted report stays
+    # visible and a pre-draft resubmission slot prompts the correction.
+    When I retrieve the reports calendar
+    Then the reports calendar contains the following items for the year 2025 and period 8
+      | SubmissionNumber | PeriodStatus          | ReportStatus |
+      | 1                | submitted             | submitted    |
+      | 2                | requires_resubmission | none         |
+
+    # With the closed-period-adjustments flag on, drafting submission 2 for the
+    # flagged period is permitted.
+    When I create the 'monthly' report for the year 2025, period 8 and submissionNumber 2
+    Then the report is successfully created
+
+    # The resubmission slot now carries the in-flight draft; the original
+    # submitted item is unchanged and the period has not collapsed.
+    When I retrieve the reports calendar
+    Then the reports calendar contains the following items for the year 2025 and period 8
+      | SubmissionNumber | PeriodStatus          | ReportStatus |
+      | 1                | submitted             | submitted    |
+      | 2                | requires_resubmission | in_progress  |
+
+    # Submitting the resubmission collapses the period back to a single
+    # submitted item.
+    When I patch the 'monthly' report for the year 2025, period 8 and submissionNumber 2 with
+      | tonnageRecycled    | 110.5 |
+      | tonnageNotRecycled | 20    |
+      | prnRevenue         | 123.4 |
+      | freeTonnage        | 0     |
+    Then the report patch succeeds
+    When I update the 'monthly' report for the year 2025, period 8 and submissionNumber 2 with status 'ready_to_submit' and version 2
+    Then the report status is successfully updated
+    When I update the 'monthly' report for the year 2025, period 8 and submissionNumber 2 with status 'submitted' and version 3
+    Then the report status is successfully updated
+
+    When I retrieve the reports calendar
+    Then the reports calendar contains the following items for the year 2025 and period 8
+      | SubmissionNumber | PeriodStatus | ReportStatus |
+      | 2                | submitted    | submitted    |

--- a/test/features/reports-resubmission.feature
+++ b/test/features/reports-resubmission.feature
@@ -8,6 +8,9 @@ Feature: Resubmission drafts for restated closed periods
   # drafted for that period. Requires FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS
   # to be on in the backend under test (defaulted on in compose.yml).
 
+  # The year and period below (August 2025) are fixed: the summary-log upload
+  # step accepts loads only within its compliance window, so this scenario will
+  # need its dates advancing once 2025 falls outside that window.
   Background:
     Given I create a linked and migrated organisation for the following
       | wasteProcessingType |
@@ -76,7 +79,8 @@ Feature: Resubmission drafts for restated closed periods
     # The flagged period yields two calendar items: the submitted report stays
     # visible and a pre-draft resubmission slot prompts the correction.
     When I retrieve the reports calendar
-    Then the reports calendar contains the following items for the year 2025 and period 8
+    Then the reports calendar is successfully retrieved
+    And the reports calendar contains the following items for the year 2025 and period 8
       | SubmissionNumber | PeriodStatus          | ReportStatus |
       | 1                | submitted             | submitted    |
       | 2                | requires_resubmission | none         |
@@ -89,7 +93,8 @@ Feature: Resubmission drafts for restated closed periods
     # The resubmission slot now carries the in-flight draft; the original
     # submitted item is unchanged and the period has not collapsed.
     When I retrieve the reports calendar
-    Then the reports calendar contains the following items for the year 2025 and period 8
+    Then the reports calendar is successfully retrieved
+    And the reports calendar contains the following items for the year 2025 and period 8
       | SubmissionNumber | PeriodStatus          | ReportStatus |
       | 1                | submitted             | submitted    |
       | 2                | requires_resubmission | in_progress  |
@@ -108,6 +113,7 @@ Feature: Resubmission drafts for restated closed periods
     Then the report status is successfully updated
 
     When I retrieve the reports calendar
-    Then the reports calendar contains the following items for the year 2025 and period 8
+    Then the reports calendar is successfully retrieved
+    And the reports calendar contains the following items for the year 2025 and period 8
       | SubmissionNumber | PeriodStatus | ReportStatus |
       | 2                | submitted    | submitted    |

--- a/test/step-definitions/reporting.steps.js
+++ b/test/step-definitions/reporting.steps.js
@@ -147,6 +147,9 @@ When('I retrieve the reports calendar', async function () {
     `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/calendar`,
     defraIdStub.authHeader(this.userId)
   )
+})
+
+Then('the reports calendar is successfully retrieved', async function () {
   expect(this.response.statusCode).to.equal(200)
   this.reportsCalendar = await this.response.body.json()
 })
@@ -161,20 +164,26 @@ Then(
 
     expect(items).to.have.lengthOf(expected.length)
 
-    expected.forEach((expectation, index) => {
-      const item = items[index]
-      expect(item.submissionNumber).to.equal(
-        Number(expectation.SubmissionNumber)
+    // Match each expected row to its item by submissionNumber rather than by
+    // array position: the two items a resubmitting period yields share a year
+    // and period, and the test should not depend on the order the backend
+    // happens to emit them in.
+    expected.forEach((expectation) => {
+      const submissionNumber = Number(expectation.SubmissionNumber)
+      const item = items.find(
+        (candidate) => candidate.submissionNumber === submissionNumber
       )
+      expect(
+        item,
+        `no calendar item for submission ${submissionNumber}`
+      ).to.not.equal(undefined)
       expect(item.periodStatus).to.equal(expectation.PeriodStatus)
 
       if (expectation.ReportStatus === 'none') {
         expect(item.report).to.equal(null)
       } else {
         expect(item.report.status).to.equal(expectation.ReportStatus)
-        expect(item.report.submissionNumber).to.equal(
-          Number(expectation.SubmissionNumber)
-        )
+        expect(item.report.submissionNumber).to.equal(submissionNumber)
       }
     })
   }

--- a/test/step-definitions/reporting.steps.js
+++ b/test/step-definitions/reporting.steps.js
@@ -142,6 +142,44 @@ Then('the report is successfully unsubmitted', async function () {
   expect(responseData.status).to.equal('ready_to_submit')
 })
 
+When('I retrieve the reports calendar', async function () {
+  this.response = await eprBackendAPI.get(
+    `/v1/organisations/${this.organisationId}/registrations/${this.registrationId}/reports/calendar`,
+    defraIdStub.authHeader(this.userId)
+  )
+  expect(this.response.statusCode).to.equal(200)
+  this.reportsCalendar = await this.response.body.json()
+})
+
+Then(
+  'the reports calendar contains the following items for the year {int} and period {int}',
+  function (year, period, dataTable) {
+    const items = this.reportsCalendar.reportingPeriods.filter(
+      (item) => item.year === year && item.period === period
+    )
+    const expected = dataTable.hashes()
+
+    expect(items).to.have.lengthOf(expected.length)
+
+    expected.forEach((expectation, index) => {
+      const item = items[index]
+      expect(item.submissionNumber).to.equal(
+        Number(expectation.SubmissionNumber)
+      )
+      expect(item.periodStatus).to.equal(expectation.PeriodStatus)
+
+      if (expectation.ReportStatus === 'none') {
+        expect(item.report).to.equal(null)
+      } else {
+        expect(item.report.status).to.equal(expectation.ReportStatus)
+        expect(item.report.submissionNumber).to.equal(
+          Number(expectation.SubmissionNumber)
+        )
+      }
+    })
+  }
+)
+
 When(
   'I unsubmit the {string} report for the year {int}, period {int} and submissionNumber {int}',
   async function (cadence, year, period, submissionNumber) {


### PR DESCRIPTION
Ticket: [PAE-1650](https://eaflood.atlassian.net/browse/PAE-1650)
## What

Adds backend journey-test coverage for the resubmission-draft flow: when a summary log restates a period whose report has already been submitted (a closed period), the backend flags the submitted report as requiring resubmission and permits a second submission to be drafted for that period.

The new scenario walks a reprocessor organisation through:

- closing August 2025 by submitting report submission 1
- uploading a second summary log that adjusts a load in the now-closed period, flagging the submitted report
- asserting the reports calendar shows the submitted report alongside a pre-draft `requires_resubmission` slot
- creating submission 2 (permitted with the flag on) and asserting the resubmission slot now carries the in-flight draft while the original submitted item stays visible
- submitting submission 2 and asserting the period collapses back to a single submitted item

Three reusable step definitions are added: one to retrieve the reports calendar, one to assert a successful retrieval, and one to assert calendar items for a given year and period against a data table (matched by submission number, so the assertion does not depend on item ordering).

## Feature flag

The suite defaults `FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS` to on in `compose.yml` so the new behaviour is exercised. This is deliberate and applies to the whole suite, which is safe because the journey suite brings up its own backend via `compose.yml` in every context (local, CI, and the deployed journey-test service): it does not run against a shared deployed backend, so flipping the default only configures the suite's own backend.

Note on parity: the backend flag currently defaults to off and is not set in any deployed environment, so this is pre-rollout coverage of behaviour production does not yet run. The full existing suite passes with the flag on, so no existing scenario depends on it being off.

## Why

The backend change that allows resubmission draft creation and preserves the resubmission calendar state needs end-to-end coverage. The existing journey suite ran with the closed-period-adjustments flag off, so the happy path and the resulting calendar transitions were untested. This branch shares its name with the backend change's branch so journey CI builds the backend from it.

Jira: https://eaflood.atlassian.net/browse/PAE-1650


[PAE-1650]: https://eaflood.atlassian.net/browse/PAE-1650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ