### PR TITLE
PAE-000: set mise minimum_release_age to 3d

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
 [tools]
 gitleaks = "8.30.1"
 node = "24.18.0"
+
+[settings]
+minimum_release_age = "3d"


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
add `minimum_release_age = "3d"` to mise `[settings]`.

only installs tool versions released more than 3 days ago (supply-chain hardening) — standardised across the epr re/ex repos.