### PR TITLE
PAE-1590: drive the row-state backfill flag in journey tests to match prod

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -191,6 +191,7 @@ services:
       DEFRA_ID_OIDC_WELL_KNOWN_URL: http://defra-id-stub:3200/cdp-defra-id-stub/.well-known/openid-configuration
       ENTRA_OIDC_WELL_KNOWN_CONFIGURATION_URL: http://entra-stub:3010/.well-known/openid-configuration
       FEATURE_FLAG_SUMMARY_LOG_ROW_STATES: ${FEATURE_FLAG_SUMMARY_LOG_ROW_STATES:-true}
+      FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL: ${FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL:-true}
       FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS: ${FEATURE_FLAG_CLOSED_PERIOD_ADJUSTMENTS:-true}
       FEATURE_FLAG_DEV_ENDPOINTS: true
       GOVUK_NOTIFY_API_KEY: /run/secrets/govuk_notify_api_key

--- a/run-journey-tests/action.yml
+++ b/run-journey-tests/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: is this action being called from a pr in this repo?
     default: 'false'
   waste-record-states:
-    description: value for the summary-log row states feature flag in the backend under test
+    description: value for the summary-log row-state feature flags (persistence and backfill) in the backend under test
     default: 'true'
   artifact-suffix:
     description: suffix appended to uploaded artifact names to keep concurrent runs distinct
@@ -86,6 +86,7 @@ runs:
       run: |
         EPR_BACKEND=${{ steps.docker-branch.outputs.image }} \
         FEATURE_FLAG_SUMMARY_LOG_ROW_STATES=${{ inputs.waste-record-states }} \
+        FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL=${{ inputs.waste-record-states }} \
         docker compose up --wait-timeout 300 -d --quiet-pull
 
     - name: Start docker compose
@@ -94,6 +95,7 @@ runs:
       run: |
         EPR_BACKEND=${{ inputs.epr-backend }} \
         FEATURE_FLAG_SUMMARY_LOG_ROW_STATES=${{ inputs.waste-record-states }} \
+        FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL=${{ inputs.waste-record-states }} \
         docker compose up --wait-timeout 300 -d --quiet-pull
 
     - name: Wait for services to be ready


### PR DESCRIPTION
Ticket: [PAE-1590](https://eaflood.atlassian.net/browse/PAE-1590)
## What

Drives `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL` from the existing `waste-record-states` input alongside `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES`, in both the `run-journey-tests` action and `compose.yml`, defaulting it on.

## Why

Prod enables **both** row-state flags — `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES` (persistence) and `FEATURE_FLAG_SUMMARY_LOG_ROW_STATES_BACKFILL` (the estate-wide startup backfill) — in [DEFRA/cdp-app-config#3922](https://github.com/DEFRA/cdp-app-config/pull/3922). [#561](https://github.com/DEFRA/epr-backend-journey-tests/pull/561) only set persistence, so journey tests ran with persistence on but backfill off. This sets both from the one input so the tests match prod.

[PAE-1590]: https://eaflood.atlassian.net/browse/PAE-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ