### PR TITLE
PAE-1730: expect PRN creation to be blocked while accreditation is suspended

### DIFF
--- a/test/features/perns-exporter.feature
+++ b/test/features/perns-exporter.feature
@@ -161,18 +161,11 @@ Feature: Packaging Recycling Notes transitions for Exporter
     When I update the accreditation status to 'suspended'
     Then the organisations data update succeeds
 
-    # We create another PRN after the accreditation is suspended
+    # Creating a PRN is not allowed while the accreditation is suspended
     When I create a PRN with the following details
       | organisationId | testId                |
       | name           | Test Organisation Ltd |
       | tradingName    | Trading Name          |
       | issuerNotes    | Testing               |
       | tonnage        | 5                     |
-    Then the PRN is successfully created
-
-    When I update the PRN status to 'awaiting_authorisation'
-    Then the PRN status is updated successfully
-
-    # Should not be allowed to issue PRN
-    When I update the PRN status to 'awaiting_acceptance'
-    Then I should receive a 403 error response 'Cannot issue a PRN on a suspended accreditation'
+    Then I should receive a 403 error response 'PRN actions require an approved accreditation (current status: suspended)'


### PR DESCRIPTION
Ticket: [PAE-1730](https://eaflood.atlassian.net/browse/PAE-1730)
## Summary

Companion to backend PR [DEFRA/epr-backend#1463](https://github.com/DEFRA/epr-backend/pull/1463) (PAE-1730), which makes PRN issuance **and draft creation** require an `approved` accreditation.

The `perns-exporter` scenario previously **created** a PRN against a **suspended** accreditation and only expected *issuance* to be blocked — relying on the old behaviour where PRN draft creation had no status guard. With the backend change, creation itself is now rejected.

## Changes

- `test/features/perns-exporter.feature` — after suspending the accreditation, the scenario now asserts that **creating** a PRN is rejected with `403 'PRN actions require an approved accreditation (current status: suspended)'`, replacing the old "create succeeds, then issue is blocked with 'Cannot issue a PRN on a suspended accreditation'" steps.

Branch name matches the backend PR branch so the backend PR's journey-test job runs against these changes.


[PAE-1730]: https://eaflood.atlassian.net/browse/PAE-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ