### PR TITLE
PAE-1730: cover a cancelled accreditation blocking PRN issue and create

### DIFF
--- a/test/features/perns-exporter.feature
+++ b/test/features/perns-exporter.feature
@@ -176,3 +176,19 @@ Feature: Packaging Recycling Notes transitions for Exporter
     # Should not be allowed to issue PRN
     When I update the PRN status to 'awaiting_acceptance'
     Then I should receive a 403 error response 'Cannot issue a PRN on a suspended accreditation'
+
+    # Once the accreditation is cancelled, the pending PRN cannot be issued and
+    # no new PRN can be created
+    When I update the accreditation status to 'cancelled'
+    Then the organisations data update succeeds
+
+    When I update the PRN status to 'awaiting_acceptance'
+    Then I should receive a 403 error response 'Cannot issue a PRN on a cancelled accreditation'
+
+    When I create a PRN with the following details
+      | organisationId | testId                |
+      | name           | Test Organisation Ltd |
+      | tradingName    | Trading Name          |
+      | issuerNotes    | Testing               |
+      | tonnage        | 5                     |
+    Then I should receive a 403 error response 'Cannot create a PRN on a cancelled accreditation'


### PR DESCRIPTION
Ticket: [PAE-1730](https://eaflood.atlassian.net/browse/PAE-1730)
## Summary

Companion to backend PR [DEFRA/epr-backend#1463](https://github.com/DEFRA/epr-backend/pull/1463) (PAE-1730), which restricts PRN actions by accreditation status:

- **suspended** → can still create/draft a PRN, cannot issue (unchanged)
- **cancelled** → can neither create nor issue

The existing `perns-exporter` scenario already covers the suspended case. This adds coverage for the new **cancelled** behaviour.

## Changes

- `test/features/perns-exporter.feature` — after the suspended block, cancel the accreditation and assert:
  - issuing the pending PRN → `403 'Cannot issue a PRN on a cancelled accreditation'`
  - creating a new PRN → `403 'Cannot create a PRN on a cancelled accreditation'`

Branch name matches the backend PR branch so #1463's journey-test job runs against these changes. (Depends on the backend change; not mergeable to `main` until #1463 lands.)


[PAE-1730]: https://eaflood.atlassian.net/browse/PAE-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ