### PR TITLE
PAE-000: trial parallel journey tests (serial overseas pass)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",
     "test:smoketest": "cucumber-js --tags \"@smoketest\" ; npm run report",
     "test:tagged": "cucumber-js --tags",
-    "test": "cucumber-js --tags \"not @smoketest and not @localonly\" ; npm run report"
+    "test": "cucumber-js --parallel 4 --tags \"not @smoketest and not @localonly and not @overseas_sites\" ; cucumber-js --tags \"@overseas_sites and not @smoketest and not @localonly\" ; npm run report"
   },
   "dependencies": {
     "allure-commandline": "2.43.0",


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
trial branch to measure CI wall-clock with cucumber-js --parallel 4.

- runs the bulk of the suite across 4 workers
- keeps @overseas_sites scenarios in a serial pass (they wipe the shared overseas-sites collection)

not for merge — measuring the parallel speedup and how costly the overseas serial tail is.