### PR TITLE
PAE-1746: Allow transition from cancelled to approved

### DIFF
--- a/test/features/perns-exporter.feature
+++ b/test/features/perns-exporter.feature
@@ -192,3 +192,15 @@ Feature: Packaging Recycling Notes transitions for Exporter
       | issuerNotes    | Testing               |
       | tonnage        | 5                     |
     Then I should receive a 403 error response 'Cannot create a PRN on a cancelled accreditation'
+
+    # We now allow transition from cancelled to approved
+    When I update the accreditation status to 'approved'
+    Then the organisations data update succeeds
+
+    When I create a PRN with the following details
+      | organisationId | testId                |
+      | name           | Test Organisation Ltd |
+      | tradingName    | Trading Name          |
+      | issuerNotes    | Testing               |
+      | tonnage        | 5                     |
+    Then the PRN is successfully created


### PR DESCRIPTION
Ticket: [PAE-1746](https://eaflood.atlassian.net/browse/PAE-1746)
## Description

Allow accreditation to move from cancelled to approved, hence PRN being able to be created.

Please see the [Pull Requests standards](https://defra.github.io/software-development-standards/processes/pull_requests).


[PAE-1746]: https://eaflood.atlassian.net/browse/PAE-1746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ