### PR TITLE
PAE-000: require curly braces around control statements

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,7 @@ export default [
   ...ns,
   {
     rules: {
+      curly: ['error', 'all'],
       camelcase: [
         'error',
         {

--- a/test/step-definitions/reporting.steps.js
+++ b/test/step-definitions/reporting.steps.js
@@ -23,7 +23,9 @@ Then(
     const reportData = await this.response.body.json()
 
     function normalise(value) {
-      if (typeof value !== 'number') return value
+      if (typeof value !== 'number') {
+        return value
+      }
       return Number.isInteger(value) ? value : value.toFixed(2)
     }
 

--- a/test/step-definitions/summarylogs.steps.js
+++ b/test/step-definitions/summarylogs.steps.js
@@ -386,7 +386,9 @@ Then(
           ]
 
           return checks.every(([expectedKey, actual]) => {
-            if (expectedResult[expectedKey] === undefined) return true
+            if (expectedResult[expectedKey] === undefined) {
+              return true
+            }
 
             const actualValue = actual.includes('.')
               ? actual.split('.').reduce((obj, key) => obj?.[key], failure)
@@ -436,7 +438,9 @@ Then(
         ]
 
         return checks.every(([expectedKey, actual]) => {
-          if (expectedResult[expectedKey] === undefined) return true
+          if (expectedResult[expectedKey] === undefined) {
+            return true
+          }
 
           const actualValue = actual.includes('.')
             ? actual.split('.').reduce((obj, key) => obj?.[key], issue)
@@ -531,7 +535,9 @@ Then(
 
         const groupedByType = wasteRecords.reduce((acc, rec) => {
           const type = rec.type
-          if (!acc[type]) acc[type] = []
+          if (!acc[type]) {
+            acc[type] = []
+          }
           acc[type].push(rec)
           return acc
         }, {})


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
adds eslint `curly: ['error', 'all']` rule to require braces around all if/else/for/while bodies, and braces existing violations, catching before commit what sonarqube flags.