### PR TITLE
PAE-000: fix Snyk brace-expansion vuln by relocking to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3520,9 +3520,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7856,9 +7856,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"


### PR DESCRIPTION
Ticket: [PAE-000](https://eaflood.atlassian.net/browse/PAE-000)
## Summary

- Remediates **CVE-2026-13149 / SNYK-JS-BRACEEXPANSION-17706650** (high, CWE-407): inefficient algorithmic complexity in `brace-expansion`'s `expand` function — crafted input with consecutive non-expanding `{}` groups causes excessive CPU consumption and blocks the event loop.
- All vulnerable copies were already within their declared semver ranges, so a targeted `npm update brace-expansion` relocks them to the patched releases (1.1.16 / 2.1.2 / 5.0.7). Lockfile-only change; no `package.json` edits.

## Changes

- `package-lock.json` — relocked all `brace-expansion` instances to patched versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
